### PR TITLE
fix(template): contain long text across all layouts

### DIFF
--- a/packages/resume-templates/scripts/render-pdf-smoke.mjs
+++ b/packages/resume-templates/scripts/render-pdf-smoke.mjs
@@ -17,19 +17,19 @@ const webFontsDir = resolve(packageDir, '../../apps/web/public/fonts');
 Font.register({
   family: 'Source Han Sans SC',
   fonts: [
-    { src: join(webFontsDir, 'SourceHanSansSC-Regular.woff'), fontWeight: 400 },
-    { src: join(webFontsDir, 'SourceHanSansSC-RegularOblique.woff'), fontWeight: 400, fontStyle: 'italic' },
-    { src: join(webFontsDir, 'SourceHanSansSC-Bold.woff'), fontWeight: 700 },
-    { src: join(webFontsDir, 'SourceHanSansSC-BoldOblique.woff'), fontWeight: 700, fontStyle: 'italic' },
+    { src: join(webFontsDir, 'SourceHanSansSC-Regular.woff2'), fontWeight: 400 },
+    { src: join(webFontsDir, 'SourceHanSansSC-RegularOblique.woff2'), fontWeight: 400, fontStyle: 'italic' },
+    { src: join(webFontsDir, 'SourceHanSansSC-Bold.woff2'), fontWeight: 700 },
+    { src: join(webFontsDir, 'SourceHanSansSC-BoldOblique.woff2'), fontWeight: 700, fontStyle: 'italic' },
   ],
 });
 Font.register({
   family: 'Source Han Serif SC',
   fonts: [
-    { src: join(webFontsDir, 'SourceHanSerifSC-Regular.woff'), fontWeight: 400 },
-    { src: join(webFontsDir, 'SourceHanSerifSC-RegularOblique.woff'), fontWeight: 400, fontStyle: 'italic' },
-    { src: join(webFontsDir, 'SourceHanSerifSC-Bold.woff'), fontWeight: 700 },
-    { src: join(webFontsDir, 'SourceHanSerifSC-BoldOblique.woff'), fontWeight: 700, fontStyle: 'italic' },
+    { src: join(webFontsDir, 'SourceHanSerifSC-Regular.woff2'), fontWeight: 400 },
+    { src: join(webFontsDir, 'SourceHanSerifSC-RegularOblique.woff2'), fontWeight: 400, fontStyle: 'italic' },
+    { src: join(webFontsDir, 'SourceHanSerifSC-Bold.woff2'), fontWeight: 700 },
+    { src: join(webFontsDir, 'SourceHanSerifSC-BoldOblique.woff2'), fontWeight: 700, fontStyle: 'italic' },
   ],
 });
 Font.registerHyphenationCallback(magicPdfHyphenationCallback);
@@ -135,7 +135,11 @@ try {
 
     const mediaBox = pdfSource.match(/\/MediaBox \[0 0 ([\d.]+) ([\d.]+)\]/);
     assert.ok(mediaBox, `${template.id} PDF did not contain a page MediaBox`);
-    assert.ok(Math.abs(Number(mediaBox[1]) - 595.28) < 0.1, `${template.id} did not keep the A4 page width`);
+    const expectedPageWidth = Number.parseFloat(template.layout.containerWidth) * 72 / 96;
+    assert.ok(
+      Math.abs(Number(mediaBox[1]) - expectedPageWidth) < 0.1,
+      `${template.id} did not keep its configured page width`,
+    );
     assert.ok(Number(mediaBox[2]) > 841.89, `${template.id} did not grow beyond the A4 minimum height`);
   }
 

--- a/packages/resume-templates/scripts/render-pdf-smoke.mjs
+++ b/packages/resume-templates/scripts/render-pdf-smoke.mjs
@@ -20,19 +20,19 @@ const webFontsDir = resolve(packageDir, '../../apps/web/public/fonts/full');
 Font.register({
   family: 'Source Han Sans SC',
   fonts: [
-    { src: join(webFontsDir, 'SourceHanSansSC-Regular.woff'), fontWeight: 400 },
-    { src: join(webFontsDir, 'SourceHanSansSC-RegularOblique.woff'), fontWeight: 400, fontStyle: 'italic' },
-    { src: join(webFontsDir, 'SourceHanSansSC-Bold.woff'), fontWeight: 700 },
-    { src: join(webFontsDir, 'SourceHanSansSC-BoldOblique.woff'), fontWeight: 700, fontStyle: 'italic' },
+    { src: join(webFontsDir, 'SourceHanSansSC-Regular.woff2'), fontWeight: 400 },
+    { src: join(webFontsDir, 'SourceHanSansSC-RegularOblique.woff2'), fontWeight: 400, fontStyle: 'italic' },
+    { src: join(webFontsDir, 'SourceHanSansSC-Bold.woff2'), fontWeight: 700 },
+    { src: join(webFontsDir, 'SourceHanSansSC-BoldOblique.woff2'), fontWeight: 700, fontStyle: 'italic' },
   ],
 });
 Font.register({
   family: 'Source Han Serif SC',
   fonts: [
-    { src: join(webFontsDir, 'SourceHanSerifSC-Regular.woff'), fontWeight: 400 },
-    { src: join(webFontsDir, 'SourceHanSerifSC-RegularOblique.woff'), fontWeight: 400, fontStyle: 'italic' },
-    { src: join(webFontsDir, 'SourceHanSerifSC-Bold.woff'), fontWeight: 700 },
-    { src: join(webFontsDir, 'SourceHanSerifSC-BoldOblique.woff'), fontWeight: 700, fontStyle: 'italic' },
+    { src: join(webFontsDir, 'SourceHanSerifSC-Regular.woff2'), fontWeight: 400 },
+    { src: join(webFontsDir, 'SourceHanSerifSC-RegularOblique.woff2'), fontWeight: 400, fontStyle: 'italic' },
+    { src: join(webFontsDir, 'SourceHanSerifSC-Bold.woff2'), fontWeight: 700 },
+    { src: join(webFontsDir, 'SourceHanSerifSC-BoldOblique.woff2'), fontWeight: 700, fontStyle: 'italic' },
   ],
 });
 Font.registerHyphenationCallback(magicPdfHyphenationCallback);
@@ -200,11 +200,15 @@ try {
 
     const mediaBox = pdfSource.match(/\/MediaBox \[0 0 ([\d.]+) ([\d.]+)\]/);
     assert.ok(mediaBox, `${template.id} PDF did not contain a page MediaBox`);
-    // 595.5 而不是 A4 真值 595.2756：页宽来自模板的 containerWidth（794 CSS px），
-    // 794 × 0.75 = 595.5。794 本身是 793.7 取整来的（PAGE_WIDTH_PX 供面板用）。
-    // 差 0.22pt ≈ 0.078mm，实际无意义——但这条断言原本卡在 ±0.1，**从未通过过**，
-    // 于是整个冒烟脚本长期是红的、没人跑。放宽到 ±1 让它能真正当守卫用。
-    assert.ok(Math.abs(Number(mediaBox[1]) - 595.28) < 1, `${template.id} did not keep the A4 page width`);
+    // 期望页宽按模板自己的 containerWidth 算,不跟 A4 真值比。
+    // 这条断言原本硬比 595.28(A4)且卡在 ±0.1,**从未通过过**——页宽实际来自模板的
+    // containerWidth(794 CSS px),794 × 0.75 = 595.5,和 A4 的 595.2756 差 0.22pt。
+    // 于是整个冒烟脚本长期是红的、没人跑。按 containerWidth 推导之后 ±0.1 才是对的。
+    const expectedPageWidth = (Number.parseFloat(template.layout.containerWidth) * 72) / 96;
+    assert.ok(
+      Math.abs(Number(mediaBox[1]) - expectedPageWidth) < 0.1,
+      `${template.id} did not keep its configured page width`,
+    );
     assert.ok(Number(mediaBox[2]) > 841.89, `${template.id} did not grow beyond the A4 minimum height`);
   }
 

--- a/packages/resume-templates/src/config/compact-cn-photo-template.ts
+++ b/packages/resume-templates/src/config/compact-cn-photo-template.ts
@@ -152,7 +152,8 @@ export const compactCnPhotoTemplate: MagicTemplateDSL = {
       props: {
         title: 'Education',
         titleZh: '教育经历',
-        columnRatio: [1.65, 1.15, 0.55],
+        columnRatio: [1.65, 0.85, 1.15],
+        shiftCenterToRightWhenRightEmpty: true,
       },
       fieldMap: {
         leftTitle: ['school'],

--- a/packages/resume-templates/src/pdf/MagicResumePdfDocument.tsx
+++ b/packages/resume-templates/src/pdf/MagicResumePdfDocument.tsx
@@ -820,6 +820,12 @@ const ThreeColumnSectionBlock = ({ component, items, context }: {
   const fields = component.fieldMap ?? {};
   const bodyFontSize = cssSizeToPoints(context.typography.fontSize.sm, 9);
   const ratios = getThreeColumnRatio(component);
+  const shiftCenterToRightWhenRightEmpty = component.props?.shiftCenterToRightWhenRightEmpty === true;
+  const shiftCenterToEmptyRight = (values: [string, string, string], enabled: boolean): [string, string, string] => (
+    enabled && values[1] && !values[2]
+      ? [values[0], '', values[1]]
+      : values
+  );
   const columnStyle = (index: number, textAlign: 'left' | 'center' | 'right'): Style => ({
     flexBasis: 0,
     flexGrow: ratios[index],
@@ -834,24 +840,32 @@ const ThreeColumnSectionBlock = ({ component, items, context }: {
       <View style={{ gap: cssSizeToPoints(context.spacing.sm, 4) }}>
         {items.map((item, index) => {
           const record = item as Record<string, unknown>;
-          const subtitles = [
+          const rawTitles: [string, string, string] = [
+            getFieldValue(record, fields.leftTitle),
+            getFieldValue(record, fields.centerTitle),
+            getFieldValue(record, fields.rightTitle),
+          ];
+          const shouldShiftCenter = shiftCenterToRightWhenRightEmpty && Boolean(rawTitles[1]) && !rawTitles[2];
+          const titles = shiftCenterToEmptyRight(rawTitles, shouldShiftCenter);
+          const rawSubtitles: [string, string, string] = [
             getFieldValue(record, fields.leftSubtitle),
             getFieldValue(record, fields.centerSubtitle),
             getFieldValue(record, fields.rightSubtitle),
           ];
+          const subtitles = shiftCenterToEmptyRight(rawSubtitles, shouldShiftCenter);
           const description = getFieldValue(record, fields.description);
 
           return (
             <View key={item.id || index}>
               <View wrap={false} minPresenceAhead={bodyFontSize * 2.5} style={{ flexDirection: 'row', gap: 8 }}>
                 <Text style={[columnStyle(0, 'left'), { color: context.colors.text, fontSize: bodyFontSize, fontWeight: 700 }]}>
-                  {getFieldValue(record, fields.leftTitle)}
+                  {titles[0]}
                 </Text>
                 <Text style={[columnStyle(1, 'center'), { color: context.colors.text, fontSize: bodyFontSize, fontWeight: 700 }]}>
-                  {getFieldValue(record, fields.centerTitle)}
+                  {titles[1]}
                 </Text>
                 <Text style={[columnStyle(2, 'right'), { color: context.colors.text, fontSize: bodyFontSize, fontWeight: 700 }]}>
-                  {getFieldValue(record, fields.rightTitle)}
+                  {titles[2]}
                 </Text>
               </View>
               {subtitles.some(Boolean) ? (
@@ -896,14 +910,19 @@ const InlineKeyValueSectionBlock = ({ component, items, context }: {
           const renderedLabel = /[:：]$/.test(label) ? label : `${label}${suffix}`;
 
           return (
-            <View key={item.id || index} style={{ flexDirection: 'row', alignItems: 'flex-start', gap: 3 }}>
+            <View
+              key={item.id || index}
+              style={{ flexDirection: 'row', alignItems: 'flex-start', gap: 3, maxWidth: '100%', minWidth: 0 }}
+            >
               {label ? (
-                <Text style={{ color: context.colors.text, fontSize: bodyFontSize, fontWeight: 700, flexShrink: 0 }}>
+                <Text
+                  style={{ color: context.colors.text, fontSize: bodyFontSize, fontWeight: 700, flexShrink: 0, maxWidth: '40%' }}
+                >
                   {renderedLabel}
                 </Text>
               ) : null}
               {detail ? (
-                <View style={{ flexGrow: 1, flexShrink: 1, minWidth: 0 }}>
+                <View style={{ flexBasis: 0, flexGrow: 1, flexShrink: 1, maxWidth: '100%', minWidth: 0 }}>
                   <PdfRichText
                     html={detail}
                     color={context.colors.text}
@@ -975,7 +994,7 @@ const TimelineBlock = ({ component, items, context }: {
   const color = component.style?.color ?? context.colors.text;
   const dateFontFamily = getPdfFontStack(context.typography.fontFamily.primary, context.cjkFallback);
   return (
-    <View style={toPdfComponentStyle(component.style)}>
+    <View style={[toPdfComponentStyle(component.style), { flexShrink: 1, maxWidth: '100%', minWidth: 0 }]}>
       <SectionTitle
         title={resolveTitle(component, context.locale)}
         icon={getSectionIcon(component)}
@@ -983,7 +1002,7 @@ const TimelineBlock = ({ component, items, context }: {
         dividerColor={context.colors.primary}
         context={context}
       />
-      <View style={{ gap: cssSizeToPoints(context.spacing.md, 8) }}>
+      <View style={{ flexShrink: 1, gap: cssSizeToPoints(context.spacing.md, 8), maxWidth: '100%', minWidth: 0 }}>
         {items.map((item, index) => {
           const record = item as Record<string, unknown>;
           const title = getFieldValue(record, fields.title ?? ['company', 'school', 'name']);
@@ -992,14 +1011,14 @@ const TimelineBlock = ({ component, items, context }: {
           const location = getFieldValue(record, ['location']);
           const description = getFieldValue(record, fields.description ?? ['summary', 'description']);
           return (
-            <View key={item.id || index} wrap={false} style={{ flexDirection: 'row', gap: 7 }}>
+            <View key={item.id || index} wrap={false} style={{ flexDirection: 'row', flexShrink: 1, gap: 7, maxWidth: '100%', minWidth: 0 }}>
               <View style={{ alignItems: 'center', width: 7 }}>
                 <View style={{ width: 6, height: 6, borderRadius: 3, backgroundColor: context.colors.primary, marginTop: 2 }} />
                 {index < items.length - 1 ? <View style={{ width: 0.75, flexGrow: 1, minHeight: 18, backgroundColor: context.colors.border }} /> : null}
               </View>
-              <View style={{ flexGrow: 1, flexShrink: 1, gap: 2 }}>
-                <View style={{ flexDirection: 'row', justifyContent: 'space-between', gap: 8 }}>
-                  <View style={{ flexGrow: 1, flexShrink: 1, gap: 1 }}>
+              <View style={{ flexBasis: 0, flexGrow: 1, flexShrink: 1, gap: 2, maxWidth: '100%', minWidth: 0 }}>
+                <View style={{ flexDirection: 'row', flexShrink: 1, justifyContent: 'space-between', gap: 8, maxWidth: '100%', minWidth: 0 }}>
+                  <View style={{ flexBasis: 0, flexGrow: 1, flexShrink: 1, gap: 1, minWidth: 0 }}>
                     <Text style={{ color, fontSize: 9, fontWeight: 700 }}>{title}</Text>
                     {subtitle ? <Text style={{ color: context.colors.primary, fontSize: 8, fontWeight: 700 }}>{subtitle}</Text> : null}
                     {location ? <Text style={{ color, fontSize: 7.5, opacity: 0.75 }}>{location}</Text> : null}
@@ -1120,6 +1139,8 @@ export const MagicResumePdfDocument = ({ data, template, locale, cjkFallback = f
             style={{
               width: sidebarWidth,
               flexShrink: 0,
+              maxWidth: sidebarWidth,
+              minWidth: 0,
               backgroundColor: colors.sidebar ?? colors.primary,
               padding: columnPadding,
               gap: columnSectionGap,
@@ -1131,6 +1152,7 @@ export const MagicResumePdfDocument = ({ data, template, locale, cjkFallback = f
             style={{
               width: mainColumnWidth,
               flexShrink: 1,
+              maxWidth: mainColumnWidth,
               minWidth: 0,
               padding: columnPadding,
               gap: columnSectionGap,

--- a/packages/resume-templates/src/pdf/MagicResumePdfDocument.tsx
+++ b/packages/resume-templates/src/pdf/MagicResumePdfDocument.tsx
@@ -845,6 +845,12 @@ const ThreeColumnSectionBlock = ({ component, items, context }: {
   const fields = component.fieldMap ?? {};
   const bodyFontSize = cssSizeToPoints(context.typography.fontSize.sm, 9);
   const ratios = getThreeColumnRatio(component);
+  const shiftCenterToRightWhenRightEmpty = component.props?.shiftCenterToRightWhenRightEmpty === true;
+  const shiftCenterToEmptyRight = (values: [string, string, string], enabled: boolean): [string, string, string] => (
+    enabled && values[1] && !values[2]
+      ? [values[0], '', values[1]]
+      : values
+  );
   const columnStyle = (index: number, textAlign: 'left' | 'center' | 'right'): Style => ({
     flexBasis: 0,
     flexGrow: ratios[index],
@@ -859,24 +865,32 @@ const ThreeColumnSectionBlock = ({ component, items, context }: {
       <View style={{ gap: cssSizeToPoints(context.spacing.sm, 4) }}>
         {items.map((item, index) => {
           const record = item as Record<string, unknown>;
-          const subtitles = [
+          const rawTitles: [string, string, string] = [
+            getFieldValue(record, fields.leftTitle),
+            getFieldValue(record, fields.centerTitle),
+            getFieldValue(record, fields.rightTitle),
+          ];
+          const shouldShiftCenter = shiftCenterToRightWhenRightEmpty && Boolean(rawTitles[1]) && !rawTitles[2];
+          const titles = shiftCenterToEmptyRight(rawTitles, shouldShiftCenter);
+          const rawSubtitles: [string, string, string] = [
             getFieldValue(record, fields.leftSubtitle),
             getFieldValue(record, fields.centerSubtitle),
             getFieldValue(record, fields.rightSubtitle),
           ];
+          const subtitles = shiftCenterToEmptyRight(rawSubtitles, shouldShiftCenter);
           const description = getFieldValue(record, fields.description);
 
           return (
             <View key={item.id || index}>
               <View wrap={false} minPresenceAhead={bodyFontSize * 2.5} style={{ flexDirection: 'row', gap: 8 }}>
                 <Text style={[columnStyle(0, 'left'), { color: context.colors.text, fontSize: bodyFontSize, fontWeight: 700 }]}>
-                  {getFieldValue(record, fields.leftTitle)}
+                  {titles[0]}
                 </Text>
                 <Text style={[columnStyle(1, 'center'), { color: context.colors.text, fontSize: bodyFontSize, fontWeight: 700 }]}>
-                  {getFieldValue(record, fields.centerTitle)}
+                  {titles[1]}
                 </Text>
                 <Text style={[columnStyle(2, 'right'), { color: context.colors.text, fontSize: bodyFontSize, fontWeight: 700 }]}>
-                  {getFieldValue(record, fields.rightTitle)}
+                  {titles[2]}
                 </Text>
               </View>
               {subtitles.some(Boolean) ? (
@@ -921,14 +935,19 @@ const InlineKeyValueSectionBlock = ({ component, items, context }: {
           const renderedLabel = /[:：]$/.test(label) ? label : `${label}${suffix}`;
 
           return (
-            <View key={item.id || index} style={{ flexDirection: 'row', alignItems: 'flex-start', gap: 3 }}>
+            <View
+              key={item.id || index}
+              style={{ flexDirection: 'row', alignItems: 'flex-start', gap: 3, maxWidth: '100%', minWidth: 0 }}
+            >
               {label ? (
-                <Text style={{ color: context.colors.text, fontSize: bodyFontSize, fontWeight: 700, flexShrink: 0 }}>
+                <Text
+                  style={{ color: context.colors.text, fontSize: bodyFontSize, fontWeight: 700, flexShrink: 0, maxWidth: '40%' }}
+                >
                   {renderedLabel}
                 </Text>
               ) : null}
               {detail ? (
-                <View style={{ flexGrow: 1, flexShrink: 1, minWidth: 0 }}>
+                <View style={{ flexBasis: 0, flexGrow: 1, flexShrink: 1, maxWidth: '100%', minWidth: 0 }}>
                   <PdfRichText
                     html={detail}
                     color={context.colors.text}
@@ -1000,7 +1019,7 @@ const TimelineBlock = ({ component, items, context }: {
   const color = component.style?.color ?? context.colors.text;
   const dateFontFamily = getPdfFontStack(context.typography.fontFamily.primary, context.cjkFallback);
   return (
-    <View style={toPdfComponentStyle(component.style)}>
+    <View style={[toPdfComponentStyle(component.style), { flexShrink: 1, maxWidth: '100%', minWidth: 0 }]}>
       <SectionTitle
         title={resolveTitle(component, context.locale)}
         icon={getSectionIcon(component)}
@@ -1008,7 +1027,7 @@ const TimelineBlock = ({ component, items, context }: {
         dividerColor={context.colors.primary}
         context={context}
       />
-      <View style={{ gap: cssSizeToPoints(context.spacing.md, 8) }}>
+      <View style={{ flexShrink: 1, gap: cssSizeToPoints(context.spacing.md, 8), maxWidth: '100%', minWidth: 0 }}>
         {items.map((item, index) => {
           const record = item as Record<string, unknown>;
           const title = getFieldValue(record, fields.title ?? ['company', 'school', 'name']);
@@ -1017,14 +1036,14 @@ const TimelineBlock = ({ component, items, context }: {
           const location = getFieldValue(record, ['location']);
           const description = getFieldValue(record, fields.description ?? ['summary', 'description']);
           return (
-            <View key={item.id || index} wrap={false} style={{ flexDirection: 'row', gap: 7 }}>
+            <View key={item.id || index} wrap={false} style={{ flexDirection: 'row', flexShrink: 1, gap: 7, maxWidth: '100%', minWidth: 0 }}>
               <View style={{ alignItems: 'center', width: 7 }}>
                 <View style={{ width: 6, height: 6, borderRadius: 3, backgroundColor: context.colors.primary, marginTop: 2 }} />
                 {index < items.length - 1 ? <View style={{ width: 0.75, flexGrow: 1, minHeight: 18, backgroundColor: context.colors.border }} /> : null}
               </View>
-              <View style={{ flexGrow: 1, flexShrink: 1, gap: 2 }}>
-                <View style={{ flexDirection: 'row', justifyContent: 'space-between', gap: 8 }}>
-                  <View style={{ flexGrow: 1, flexShrink: 1, gap: 1 }}>
+              <View style={{ flexBasis: 0, flexGrow: 1, flexShrink: 1, gap: 2, maxWidth: '100%', minWidth: 0 }}>
+                <View style={{ flexDirection: 'row', flexShrink: 1, justifyContent: 'space-between', gap: 8, maxWidth: '100%', minWidth: 0 }}>
+                  <View style={{ flexBasis: 0, flexGrow: 1, flexShrink: 1, gap: 1, minWidth: 0 }}>
                     <Text style={{ color, fontSize: 9, fontWeight: 700 }}>{title}</Text>
                     {subtitle ? <Text style={{ color: context.colors.primary, fontSize: 8, fontWeight: 700 }}>{subtitle}</Text> : null}
                     {location ? <Text style={{ color, fontSize: 7.5, opacity: 0.75 }}>{location}</Text> : null}
@@ -1177,6 +1196,8 @@ export const MagicResumePdfDocument = ({ data, template, locale, cjkFallback = f
             style={{
               width: sidebarWidth,
               flexShrink: 0,
+              maxWidth: sidebarWidth,
+              minWidth: 0,
               backgroundColor: colors.sidebar ?? colors.primary,
               padding: columnPadding,
               gap: columnSectionGap,
@@ -1188,6 +1209,7 @@ export const MagicResumePdfDocument = ({ data, template, locale, cjkFallback = f
             style={{
               width: mainColumnWidth,
               flexShrink: 1,
+              maxWidth: mainColumnWidth,
               minWidth: 0,
               padding: columnPadding,
               gap: columnSectionGap,

--- a/packages/resume-templates/src/pdf/hyphenation.ts
+++ b/packages/resume-templates/src/pdf/hyphenation.ts
@@ -1,8 +1,11 @@
 const cjkCharacterRegex = /[\u3040-\u30ff\u3400-\u9fff\uac00-\ud7af]/;
+const MIN_BREAKABLE_WORD_LENGTH = 16;
 
 export const magicPdfHyphenationCallback = (word: string): string[] => {
   if (word === ' ') return [word];
-  if (!cjkCharacterRegex.test(word)) return [word];
+  if (!cjkCharacterRegex.test(word) && Array.from(word).length < MIN_BREAKABLE_WORD_LENGTH) {
+    return [word];
+  }
 
   // Empty fragments expose character-level break opportunities without
   // asking textkit to paint a hyphen at the end of the wrapped line.

--- a/packages/resume-templates/src/templateLayout/InlineKeyValueSection.tsx
+++ b/packages/resume-templates/src/templateLayout/InlineKeyValueSection.tsx
@@ -75,10 +75,20 @@ export const InlineKeyValueSection = React.memo(function InlineKeyValueSection({
             ?? getFieldEntry(item, fieldMap.itemDetail);
 
           return (
-            <div key={itemId || index} className="flex min-w-0 items-start gap-x-1">
-              {label && <div className="shrink-0 font-bold">{withSuffix(label, labelSuffix)}</div>}
+            <div key={itemId || index} className="flex min-w-0 max-w-full items-start gap-x-1">
+              {label && (
+                <div
+                  className="shrink-0 font-bold"
+                  style={{ maxWidth: '40%', overflowWrap: 'anywhere', wordBreak: 'break-word' }}
+                >
+                  {withSuffix(label, labelSuffix)}
+                </div>
+              )}
               {detail && (
-                <div className="min-w-0 flex-1">
+                <div
+                  className="min-w-0 flex-1"
+                  style={{ overflowWrap: 'anywhere', wordBreak: 'break-word' }}
+                >
                   {sectionKey && itemId ? (
                     <Editable
                       target={{

--- a/packages/resume-templates/src/templateLayout/Layout.tsx
+++ b/packages/resume-templates/src/templateLayout/Layout.tsx
@@ -30,8 +30,14 @@ export function Layout({ children, layout, designTokens, style }: Props) {
   const innerStyle: React.CSSProperties = {
     padding: layout.padding,
     gap: layout.gap,
+    boxSizing: 'border-box',
+    maxWidth: '100%',
+    minWidth: 0,
+    width: '100%',
     lineHeight: 'var(--line-height)',
     letterSpacing: 'var(--letter-spacing)',
+    overflowWrap: 'anywhere',
+    wordBreak: 'break-word',
   };
 
   return (
@@ -45,4 +51,4 @@ export function Layout({ children, layout, designTokens, style }: Props) {
       </div>
     </div>
   );
-} 
+}

--- a/packages/resume-templates/src/templateLayout/ThreeColumnSection.tsx
+++ b/packages/resume-templates/src/templateLayout/ThreeColumnSection.tsx
@@ -17,7 +17,25 @@ interface Props {
   titleIcon?: React.ComponentType<{ size?: number; style?: React.CSSProperties }>;
   sectionKey?: string;
   columnRatio?: [number, number, number];
+  shiftCenterToRightWhenRightEmpty?: boolean;
 }
+
+type ColumnValue = string | null;
+
+const shiftCenterToEmptyRight = (
+  values: [ColumnValue, ColumnValue, ColumnValue],
+  enabled: boolean,
+): [ColumnValue, ColumnValue, ColumnValue] => (
+  enabled && values[1] && !values[2]
+    ? [values[0], '', values[1]]
+    : values
+);
+
+const breakableTextStyle: React.CSSProperties = {
+  minWidth: 0,
+  overflowWrap: 'anywhere',
+  wordBreak: 'break-word',
+};
 
 export const ThreeColumnSection = React.memo(function ThreeColumnSection({
   title,
@@ -29,6 +47,7 @@ export const ThreeColumnSection = React.memo(function ThreeColumnSection({
   titleIcon: TitleIcon,
   sectionKey,
   columnRatio = [1.65, 0.85, 1.15],
+  shiftCenterToRightWhenRightEmpty = false,
 }: Props) {
   if (!items || items.length === 0) return null;
 
@@ -68,25 +87,33 @@ export const ThreeColumnSection = React.memo(function ThreeColumnSection({
         {items.map((item, index) => {
           const itemId = item.id != null ? String(item.id) : null;
           const description = getFieldEntry(item, fieldMap.description);
-          const subtitles = [
+          const rawTitles: [ColumnValue, ColumnValue, ColumnValue] = [
+            getFieldValue(item, fieldMap.leftTitle),
+            getFieldValue(item, fieldMap.centerTitle),
+            getFieldValue(item, fieldMap.rightTitle),
+          ];
+          const shouldShiftCenter = shiftCenterToRightWhenRightEmpty && Boolean(rawTitles[1]) && !rawTitles[2];
+          const titles = shiftCenterToEmptyRight(rawTitles, shouldShiftCenter);
+          const rawSubtitles: [ColumnValue, ColumnValue, ColumnValue] = [
             getFieldValue(item, fieldMap.leftSubtitle),
             getFieldValue(item, fieldMap.centerSubtitle),
             getFieldValue(item, fieldMap.rightSubtitle),
           ];
+          const subtitles = shiftCenterToEmptyRight(rawSubtitles, shouldShiftCenter);
           const hasSubtitles = subtitles.some(Boolean);
 
           return (
             <div key={itemId || index} className="min-w-0">
               <div className="grid items-start gap-x-3 font-bold" style={{ gridTemplateColumns: columns }}>
-                <div className="min-w-0 text-left">{getFieldValue(item, fieldMap.leftTitle)}</div>
-                <div className="min-w-0 text-center">{getFieldValue(item, fieldMap.centerTitle)}</div>
-                <div className="min-w-0 text-right">{getFieldValue(item, fieldMap.rightTitle)}</div>
+                <div className="min-w-0 text-left" style={breakableTextStyle}>{titles[0]}</div>
+                <div className="min-w-0 text-center" style={breakableTextStyle}>{titles[1]}</div>
+                <div className="min-w-0 text-right" style={breakableTextStyle}>{titles[2]}</div>
               </div>
               {hasSubtitles && (
                 <div className="grid items-start gap-x-3" style={{ gridTemplateColumns: columns }}>
-                  <div className="min-w-0 text-left">{subtitles[0]}</div>
-                  <div className="min-w-0 text-center">{subtitles[1]}</div>
-                  <div className="min-w-0 text-right">{subtitles[2]}</div>
+                  <div className="min-w-0 text-left" style={breakableTextStyle}>{subtitles[0]}</div>
+                  <div className="min-w-0 text-center" style={breakableTextStyle}>{subtitles[1]}</div>
+                  <div className="min-w-0 text-right" style={breakableTextStyle}>{subtitles[2]}</div>
                 </div>
               )}
               {description && (

--- a/packages/resume-templates/src/templateLayout/Timeline.tsx
+++ b/packages/resume-templates/src/templateLayout/Timeline.tsx
@@ -30,6 +30,8 @@ export const Timeline = React.memo(function Timeline({ title, items, fieldMap = 
       className="space-y-6"
       style={{
         ...style,
+        maxWidth: '100%',
+        minWidth: 0,
         lineHeight: 'var(--line-height)',
         letterSpacing: 'var(--letter-spacing)',
         marginBottom: 'var(--section-spacing)',
@@ -65,7 +67,7 @@ export const Timeline = React.memo(function Timeline({ title, items, fieldMap = 
           const itemId = item.id != null ? String(item.id) : null;
 
           return (
-            <div key={itemId || idx} className="relative pl-6">
+            <div key={itemId || idx} className="relative min-w-0 max-w-full pl-6">
               <div 
                 style={{
                   position: 'absolute',
@@ -93,9 +95,9 @@ export const Timeline = React.memo(function Timeline({ title, items, fieldMap = 
                 />
               )}
               
-              <div className="space-y-2">
-                <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start">
-                  <div>
+              <div className="min-w-0 max-w-full space-y-2">
+                <div className="flex min-w-0 max-w-full flex-col sm:flex-row sm:items-start sm:justify-between">
+                  <div className="min-w-0 flex-1">
                     <h3 className="font-bold" style={{ color: textColor, fontSize: 'var(--font-size-body)' }}>
                       {company}
                     </h3>
@@ -112,14 +114,14 @@ export const Timeline = React.memo(function Timeline({ title, items, fieldMap = 
                   </div>
                   
                   {date && (
-                    <div className="font-medium mt-1 sm:mt-0" style={{ color: secondaryColor, fontSize: 'var(--font-size-body)' }}>
+                    <div className="mt-1 shrink-0 font-medium sm:mt-0" style={{ color: secondaryColor, fontSize: 'var(--font-size-body)' }}>
                       {date}
                     </div>
                   )}
                 </div>
                 
                 {description && (
-                  <div style={{ color: textColor, fontSize: 'var(--font-size-body)' }}>
+                  <div className="min-w-0 max-w-full" style={{ color: textColor, fontSize: 'var(--font-size-body)' }}>
                     {sectionKey && itemId ? (
                       <Editable
                         target={{

--- a/packages/resume-templates/src/templateLayout/TwoColumnLayout.tsx
+++ b/packages/resume-templates/src/templateLayout/TwoColumnLayout.tsx
@@ -37,6 +37,7 @@ export function TwoColumnLayout({ children, layout }: Props) {
   const pageMinHeight = Math.round(parseInt(layout.containerWidth) * pageAspect);
 
   const containerStyle: React.CSSProperties = {
+    boxSizing: 'border-box',
     width: 'var(--container-width)',
     maxWidth: 'var(--container-width)',
     minHeight: `${pageMinHeight}px`,
@@ -48,7 +49,10 @@ export function TwoColumnLayout({ children, layout }: Props) {
   };
 
   const sidebarStyle: React.CSSProperties = {
+    boxSizing: 'border-box',
     width: twoColumn.leftWidth,
+    maxWidth: '100%',
+    minWidth: 0,
     minHeight: `${pageMinHeight}px`,
     backgroundColor: 'var(--color-sidebar, var(--color-primary))',
     padding: 'var(--container-padding)',
@@ -60,7 +64,10 @@ export function TwoColumnLayout({ children, layout }: Props) {
   };
 
   const mainStyle: React.CSSProperties = {
+    boxSizing: 'border-box',
     width: twoColumn.rightWidth,
+    maxWidth: '100%',
+    minWidth: 0,
     color: 'var(--color-text)',
     padding: 'var(--container-padding)',
     gap: 'var(--container-gap)',
@@ -68,6 +75,8 @@ export function TwoColumnLayout({ children, layout }: Props) {
     letterSpacing: 'inherit',
     borderTopRightRadius: '0.375rem',
     borderBottomRightRadius: '0.375rem',
+    overflowWrap: 'anywhere',
+    wordBreak: 'break-word',
   };
 
   return (
@@ -98,4 +107,4 @@ export function TwoColumnLayout({ children, layout }: Props) {
       </div>
     </div>
   );
-} 
+}

--- a/packages/resume-templates/src/templateLayout/WysiwygContent.tsx
+++ b/packages/resume-templates/src/templateLayout/WysiwygContent.tsx
@@ -15,7 +15,17 @@ export function WysiwygContent({ dirtyHtml, className }: Props) {
     <div
       className={`wysiwyg ${className || ''}`}
       dangerouslySetInnerHTML={{ __html: cleanHtml }}
-      style={{ color: 'inherit' }}
+      style={{
+        boxSizing: 'border-box',
+        color: 'inherit',
+        display: 'block',
+        maxWidth: '100%',
+        minWidth: 0,
+        overflowWrap: 'anywhere',
+        whiteSpace: 'normal',
+        width: '100%',
+        wordBreak: 'break-word',
+      }}
     />
   );
-} 
+}


### PR DESCRIPTION
## Summary
- constrain long text inside shared single-column, two-column, timeline, three-column, inline key/value, and rich-text layouts in both web and PDF renderers
- keep Compact CN Photo education date/major aligned in the right column when location is absent, while preserving date/major alignment when location exists
- update PDF smoke coverage for current WOFF2 fonts and every template's configured page width

## Verification
- `npm run lint` in `packages/resume-templates`
- `npm run test:pdf`: rendered all 19 templates successfully
- pdfplumber boundary audit: 19 templates, 0 extracted text boxes outside page bounds
- visually reviewed all 7 two-column PDFs, including the new `slate-sidebar` template

Before this change, each affected legacy two-column template produced 45-54 text boxes beyond the page edge under long content. After the shared layout fix, all 19 current templates report zero overflow boxes.