### PR TITLE
feat(web): 错误终于说得清是什么错、以及该做什么

### DIFF
--- a/apps/web/scripts/i18n-logs/scan.md
+++ b/apps/web/scripts/i18n-logs/scan.md
@@ -1,3 +1,3 @@
-# i18n Scan Report (8/11/2026, 10:10:02 PM)
+# i18n Scan Report (8/12/2026, 4:32:53 AM)
 
 ✅ All checks passed! No issues found.

--- a/apps/web/src/app.test.ts
+++ b/apps/web/src/app.test.ts
@@ -1,4 +1,15 @@
 import assert from 'node:assert/strict';
+import zhCopy from '@/locales/zh/translation.json';
+import enCopy from '@/locales/en/translation.json';
+import {
+  fromErrorBody,
+  fromSseEvent,
+  fromThrown,
+  isAborted,
+} from '@/lib/errors/normalize';
+import { appErrorCopy } from '@/lib/errors/message';
+import { presentAppError } from '@/lib/errors/present';
+import { APP_ERROR_CODES, opensBillingGate } from '@/lib/errors/types';
 import { ZodError } from 'zod';
 import {
   applyChangeToSections,
@@ -883,6 +894,153 @@ function testSectionOrderCoercion() {
   assert.ok(keys.includes('skills'), 'built-in section missing after normalize');
 }
 
+/**
+ * 错误契约（Core ADR-0018）：码是后端下发的，文案是前端的。
+ *
+ * 这条覆盖测试是那条分界能成立的前提——后端加了新码而前端没写文案，就在这里红。没有它，
+ * 「文案归前端」只是一句口号，实际会退化成用户在屏幕上读到一个标识符。
+ */
+function testErrorCopyCoverage() {
+  for (const code of [...APP_ERROR_CODES, 'unknown']) {
+    for (const [lang, dict] of [['zh', zhCopy], ['en', enCopy]] as const) {
+      const copy = (dict.errors as Record<string, unknown>)[code];
+      assert.equal(
+        typeof copy,
+        'string',
+        `${lang} 缺少 errors.${code} 的文案`,
+      );
+      assert.ok((copy as string).trim().length > 0, `${lang} errors.${code} 是空串`);
+    }
+  }
+
+  // 两侧必须同构：只补一种语言等于给另一种语言的用户留了一个标识符。
+  assert.deepEqual(
+    Object.keys(zhCopy.errors).sort(),
+    Object.keys(enCopy.errors).sort(),
+    'zh / en 的 errors 键不同构',
+  );
+}
+
+/**
+ * 归一化：契约的地基。重点不是「新后端发了码」，而是**上游什么都没发时**——老后端还在
+ * 线上的那几周，前端手里只有一个状态码。
+ */
+function testErrorNormalize() {
+  // 本次修复的靶子：额度用完必须是 quota_exceeded，绝不能被读成 rate_limited。
+  const quota = fromErrorBody(
+    429,
+    {
+      code: 429,
+      message: 'quota_exhausted',
+      errorCode: 'quota_exceeded',
+      subCode: 'daily_cap',
+      params: { period: 'daily', resetAt: '2026-08-13T00:00:00Z' },
+      requestId: 'req-1',
+      retryable: false,
+    },
+    'bff',
+  );
+  assert.equal(quota.errorCode, 'quota_exceeded');
+  assert.notEqual(quota.errorCode, 'rate_limited');
+  assert.equal(quota.params?.period, 'daily');
+  assert.equal(quota.requestId, 'req-1');
+  assert.equal(quota.retryable, false);
+  assert.equal(opensBillingGate(quota.errorCode), true);
+
+  // 老后端：只有状态码。降级到今天的粒度，不会更差。
+  const legacyStatus = fromErrorBody(429, { code: 429, message: '' }, 'bff');
+  assert.equal(legacyStatus.errorCode, 'rate_limited');
+  assert.equal(legacyStatus.retryable, true);
+
+  // 老后端 + 存量字符串码：那几周里这就是全部的可用信息。
+  const legacyCode = fromErrorBody(429, { code: 'quota_exhausted' }, 'bff');
+  assert.equal(legacyCode.errorCode, 'quota_exceeded');
+  assert.equal(legacyCode.subCode, 'quota_exhausted');
+
+  // 畸形体：不能因此再抛一个错。
+  assert.equal(fromErrorBody(500, undefined, 'bff').errorCode, 'internal_error');
+  assert.equal(fromErrorBody(500, 'not json', 'bff').errorCode, 'internal_error');
+  assert.equal(fromErrorBody(undefined, {}, 'local').errorCode, 'unknown');
+
+  // 老 BFF 那句 "Backend request failed with status 429" 绝不能当文案渲染。
+  const bffNoise = fromErrorBody(
+    429,
+    { error: 'Backend request failed with status 429' },
+    'bff',
+  );
+  assert.equal(bffNoise.publicMessage, undefined);
+
+  // message 只是机器码时同样不算文案。
+  assert.equal(
+    fromErrorBody(429, { code: 'quota_exhausted', message: 'quota_exhausted' }, 'bff')
+      .publicMessage,
+    undefined,
+  );
+
+  // 网络断了是「依赖够不着」，不是「我们有 bug」。
+  const network = fromThrown(new TypeError('Failed to fetch'));
+  assert.equal(network.errorCode, 'upstream_unavailable');
+  assert.equal(network.retryable, true);
+
+  // 用户点了停止：不是故障，静默丢弃。
+  const aborted = fromThrown(Object.assign(new Error('x'), { name: 'AbortError' }));
+  assert.equal(isAborted(aborted), true);
+  assert.equal(presentAppError(aborted), null);
+
+  // SSE 帧：payload.errorCode 优先，老的 error 字段仍认。
+  assert.equal(
+    fromSseEvent({ error: 'quota_exceeded', payload: { code: 'quota_exceeded' } })
+      .errorCode,
+    'quota_exceeded',
+  );
+  assert.equal(
+    fromSseEvent({ error: 'agent_run_failed', payload: {} }).errorCode,
+    'internal_error',
+  );
+}
+
+/** 文案：本地化的码文案永远当标题，服务端那句只能是补充行。 */
+function testErrorCopy() {
+  const t = (key: string, options?: Record<string, unknown>) => {
+    const value = key
+      .split('.')
+      .reduce<unknown>(
+        (acc, part) =>
+          typeof acc === 'object' && acc !== null
+            ? (acc as Record<string, unknown>)[part]
+            : undefined,
+        zhCopy,
+      );
+    if (typeof value !== 'string') {
+      return (options?.defaultValue as string | undefined) ?? key;
+    }
+    return value.replace(/\{\{(\w+)\}\}/g, (_, name: string) =>
+      String(options?.[name] ?? ''),
+    );
+  };
+
+  const copy = appErrorCopy(
+    {
+      errorCode: 'content_rejected',
+      retryable: false,
+      source: 'sse',
+      publicMessage: 'This PDF looks like a scan — we could not read any text.',
+    },
+    t,
+  );
+  // 屏幕上永远不会只剩一句外语：标题一定是本地语言。
+  assert.equal(copy.title, zhCopy.errors.content_rejected);
+  assert.equal(copy.detail, 'This PDF looks like a scan — we could not read any text.');
+
+  // 认不出的码退到通用兜底，而不是把标识符渲染出来。
+  const unknown = appErrorCopy(
+    { errorCode: 'unknown', retryable: false, source: 'http' },
+    t,
+  );
+  assert.equal(unknown.title, zhCopy.errors.unknown);
+  assert.ok(!unknown.title.includes('errors.'));
+}
+
 async function main() {
   await testAiSessionStore();
   testImportResumeValidation();
@@ -898,6 +1056,9 @@ async function main() {
   testCustomSections();
   testSectionOwnership();
   testSectionOrderCoercion();
+  testErrorCopyCoverage();
+  testErrorNormalize();
+  testErrorCopy();
 }
 
 main().catch((error) => {

--- a/apps/web/src/app.test.ts
+++ b/apps/web/src/app.test.ts
@@ -10,6 +10,7 @@ import {
 import { appErrorCopy } from '@/lib/errors/message';
 import { presentAppError } from '@/lib/errors/present';
 import { APP_ERROR_CODES, opensBillingGate } from '@/lib/errors/types';
+import { projectUpstreamError } from '@/app/api/chat-agent/errorProjection';
 import { ZodError } from 'zod';
 import {
   applyChangeToSections,
@@ -1041,6 +1042,57 @@ function testErrorCopy() {
   assert.ok(!unknown.title.includes('errors.'));
 }
 
+/**
+ * BFF 那一跳：**白名单本身就是安全边界**。
+ *
+ * 之前是整体替换（连码都丢了），改成透传又会把上游写给运营的英文、以及这个部署配了哪些
+ * 支付渠道，一路送到买家屏幕上——commercial 那次事故泄漏的正是「available: paypal」。
+ * 所以是投影，不是代理。
+ */
+function testBffErrorProjection() {
+  const upstream = JSON.stringify({
+    code: 429,
+    message: 'Plan change unavailable: configured channels are paypal, alipay',
+    error: 'QuotaExceededError',
+    errorCode: 'quota_exceeded',
+    subCode: 'daily_cap',
+    params: { period: 'daily', resetAt: '2026-08-13T00:00:00Z' },
+    requestId: 'req-9',
+    retryable: false,
+  });
+
+  const projected = projectUpstreamError(429, upstream);
+  assert.deepEqual(projected, {
+    errorCode: 'quota_exceeded',
+    subCode: 'daily_cap',
+    params: { period: 'daily', resetAt: '2026-08-13T00:00:00Z' },
+    requestId: 'req-9',
+    retryable: false,
+    error: 'quota_exceeded',
+  });
+  // 上游原文一个字都不许过来。
+  assert.ok(!('message' in projected));
+  assert.ok(!JSON.stringify(projected).includes('paypal'));
+
+  // 老后端：只有状态码，`error` 退到一个机器可读的标识而不是英文散文。
+  assert.deepEqual(
+    projectUpstreamError(429, JSON.stringify({ code: 429, message: 'x' })),
+    { error: 'upstream_429' },
+  );
+
+  // 上游回了一页 HTML：不能因此再抛一个错。
+  assert.deepEqual(projectUpstreamError(502, '<html>502</html>'), {
+    error: 'upstream_502',
+  });
+
+  // 走完整条链：投影出来的东西，normalize 必须还能读回同一个码。
+  const roundTrip = fromErrorBody(429, projectUpstreamError(429, upstream), 'bff');
+  assert.equal(roundTrip.errorCode, 'quota_exceeded');
+  assert.notEqual(roundTrip.errorCode, 'rate_limited');
+  assert.equal(roundTrip.params?.period, 'daily');
+  assert.equal(roundTrip.requestId, 'req-9');
+}
+
 async function main() {
   await testAiSessionStore();
   testImportResumeValidation();
@@ -1059,6 +1111,7 @@ async function main() {
   testErrorCopyCoverage();
   testErrorNormalize();
   testErrorCopy();
+  testBffErrorProjection();
 }
 
 main().catch((error) => {

--- a/apps/web/src/app/api/chat-agent/approve/route.ts
+++ b/apps/web/src/app/api/chat-agent/approve/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerUserId } from '@/lib/auth/server';
 import { serverFetchBackend } from '@/lib/auth/serverFetchBackend';
+import { projectUpstreamError } from '../errorProjection';
 
 /**
  * Human-in-the-loop tool-approval reply. Forwards the user's decision and proxies
@@ -24,10 +25,10 @@ export async function POST(req: NextRequest) {
       // Log the upstream body server-side only; never surface it to the client.
       const errorText = await backendResponse.text();
       console.error(`[AGENT_APPROVE] Backend error ${backendResponse.status}: ${errorText}`);
-      // Forward the upstream status (e.g. 402) so the client's quota gate can
-      // react, but with a generic message — never surface the upstream body.
+      // 投影而非代理：只放行契约里那五个键，`message` 一律不转发——上游的 4xx 原文
+      // 可能是写给运营的英文，甚至说出这个部署配了哪些渠道（见 errorProjection.ts）。
       return NextResponse.json(
-        { error: `Backend request failed with status ${backendResponse.status}` },
+        projectUpstreamError(backendResponse.status, errorText),
         { status: backendResponse.status },
       );
     }
@@ -94,9 +95,14 @@ export async function POST(req: NextRequest) {
     const data = await backendResponse.json().catch(() => ({}));
     return NextResponse.json(data, { status: backendResponse.status });
   } catch (error: unknown) {
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    // 诊断进服务端日志，不进响应体。
+    console.error(
+      `[AGENT_APPROVE] forward failed:`,
+      error instanceof Error ? error.message : error,
+    );
     return NextResponse.json(
-      { error: '授权转发失败', errorMessage },
+      // 只回码：`errorMessage` 会把 undici 内部与内网 host 泄漏出去。
+      { errorCode: 'upstream_unavailable', error: 'upstream_unavailable', retryable: true },
       { status: 500 }
     );
   }

--- a/apps/web/src/app/api/chat-agent/edit/route.ts
+++ b/apps/web/src/app/api/chat-agent/edit/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerUserId } from '@/lib/auth/server';
 import { serverFetchBackend } from '@/lib/auth/serverFetchBackend';
+import { projectUpstreamError } from '../errorProjection';
 
 /**
  * Snippet/element-scoped edit — the living canvas' fast, in-place quick actions
@@ -31,10 +32,10 @@ export async function POST(req: NextRequest) {
       // Log the upstream body server-side only; never surface it to the client.
       const errorText = await backendResponse.text();
       console.error(`[AGENT_EDIT] Backend error ${backendResponse.status}: ${errorText}`);
-      // Forward the upstream status (e.g. 402) so the client's quota gate can
-      // react, but with a generic message — never surface the upstream body.
+      // 投影而非代理：只放行契约里那五个键，`message` 一律不转发——上游的 4xx 原文
+      // 可能是写给运营的英文，甚至说出这个部署配了哪些渠道（见 errorProjection.ts）。
       return NextResponse.json(
-        { error: `Backend request failed with status ${backendResponse.status}` },
+        projectUpstreamError(backendResponse.status, errorText),
         { status: backendResponse.status },
       );
     }
@@ -47,9 +48,14 @@ export async function POST(req: NextRequest) {
     if ((error as Error)?.name === 'AbortError') {
       return NextResponse.json({ error: 'aborted' }, { status: 499 });
     }
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    // 诊断进服务端日志，不进响应体。
+    console.error(
+      `[AGENT_EDIT] forward failed:`,
+      error instanceof Error ? error.message : error,
+    );
     return NextResponse.json(
-      { error: 'API转发失败', errorMessage },
+      // 只回码：`errorMessage` 会把 undici 内部与内网 host 泄漏出去。
+      { errorCode: 'upstream_unavailable', error: 'upstream_unavailable', retryable: true },
       { status: 500 }
     );
   }

--- a/apps/web/src/app/api/chat-agent/errorProjection.ts
+++ b/apps/web/src/app/api/chat-agent/errorProjection.ts
@@ -1,5 +1,3 @@
-import 'server-only';
-
 /**
  * 上游的失败要怎么过 BFF 这一关。
  *

--- a/apps/web/src/app/api/chat-agent/errorProjection.ts
+++ b/apps/web/src/app/api/chat-agent/errorProjection.ts
@@ -1,0 +1,58 @@
+import 'server-only';
+
+/**
+ * 上游的失败要怎么过 BFF 这一关。
+ *
+ * 三个 route 此前都是**整体替换**：`{ error: \`Backend request failed with status ${status}\` }`。
+ * 状态码活了下来，其余全丢——而下游那条按字符串匹配的正则会命中这句话里的 "429"，把
+ * 「额度用完」读成「你太快了」，充值入口于是永远不出现。
+ *
+ * 但也不能改成透传：上游的 4xx `message` 可能是写给运营的英文，甚至说出这个部署配了哪些
+ * 支付渠道。所以这里是**投影，不是代理**——白名单本身就是安全边界，只放行五个键，
+ * `message` 一律不转发。
+ */
+const FORWARDED_KEYS = [
+  'errorCode',
+  'subCode',
+  'params',
+  'requestId',
+  'retryable',
+] as const;
+
+export interface ProjectedError {
+  errorCode?: unknown;
+  subCode?: unknown;
+  params?: unknown;
+  requestId?: unknown;
+  retryable?: unknown;
+  /** 老客户端还在读它。保留形状，但只放机器码，不放上游原文。 */
+  error: string;
+}
+
+export function projectUpstreamError(
+  status: number,
+  rawBody: string,
+): ProjectedError {
+  const projected: Record<string, unknown> = {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawBody);
+  } catch {
+    parsed = undefined;
+  }
+
+  if (typeof parsed === 'object' && parsed !== null) {
+    const body = parsed as Record<string, unknown>;
+    for (const key of FORWARDED_KEYS) {
+      if (body[key] !== undefined) projected[key] = body[key];
+    }
+  }
+
+  return {
+    ...projected,
+    error:
+      typeof projected.errorCode === 'string'
+        ? projected.errorCode
+        : `upstream_${status}`,
+  };
+}

--- a/apps/web/src/app/api/chat-agent/route.ts
+++ b/apps/web/src/app/api/chat-agent/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerUserId } from '@/lib/auth/server';
 import { serverFetchBackend } from '@/lib/auth/serverFetchBackend';
+import { projectUpstreamError } from './errorProjection';
 
 export async function POST(req: NextRequest) {
     try {
@@ -23,10 +24,10 @@ export async function POST(req: NextRequest) {
             // Log the upstream body server-side only; never surface it to the client.
             const errorText = await backendResponse.text();
             console.error(`[CHAT_AGENT] Backend error ${backendResponse.status}: ${errorText}`);
-            // Forward the upstream status (e.g. 402) so the client's quota gate can
-            // react, but with a generic message — never surface the upstream body.
+            // 投影而非代理：只放行契约里那五个键，`message` 一律不转发——上游的 4xx 原文
+            // 可能是写给运营的英文，甚至说出这个部署配了哪些渠道（见 errorProjection.ts）。
             return NextResponse.json(
-                { error: `Backend request failed with status ${backendResponse.status}` },
+                projectUpstreamError(backendResponse.status, errorText),
                 { status: backendResponse.status },
             );
         }
@@ -116,14 +117,17 @@ export async function POST(req: NextRequest) {
         }
 
     } catch (error: unknown) {
-        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        // 诊断进服务端日志，不进响应体。
+        console.error(
+          `[CHAT_AGENT] forward failed:`,
+          error instanceof Error ? error.message : error,
+        );
         
+        // 只回码。`errorMessage` 装的是 undici 的内部消息与内网 host，而 editClient 的
+        // readError 第一个读的就是它——一次转发失败因此把拓扑写到了用户屏幕上。
         return NextResponse.json(
-            { 
-                error: 'API转发失败', 
-                errorMessage: errorMessage
-            },
-            { status: 500 }
+            { errorCode: 'upstream_unavailable', error: 'upstream_unavailable', retryable: true },
+            { status: 502 }
         );
     }
 }

--- a/apps/web/src/app/api/chat-agent/session/route.ts
+++ b/apps/web/src/app/api/chat-agent/session/route.ts
@@ -24,9 +24,14 @@ export async function DELETE(req: NextRequest) {
     const data = await backendResponse.json().catch(() => ({}));
     return NextResponse.json(data, { status: backendResponse.status });
   } catch (error: unknown) {
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    // 诊断进服务端日志，不进响应体。
+    console.error(
+      `[AGENT_SESSION] forward failed:`,
+      error instanceof Error ? error.message : error,
+    );
     return NextResponse.json(
-      { error: 'session 回收失败', errorMessage },
+      // 只回码：`errorMessage` 会把 undici 内部与内网 host 泄漏出去。
+      { errorCode: 'upstream_unavailable', error: 'upstream_unavailable', retryable: true },
       { status: 500 }
     );
   }

--- a/apps/web/src/app/dashboard/edit/_components/ResumeEdit.tsx
+++ b/apps/web/src/app/dashboard/edit/_components/ResumeEdit.tsx
@@ -28,6 +28,8 @@ import {
   verticalListSortingStrategy
 } from '@dnd-kit/sortable';
 import { toast } from 'sonner';
+import { fromThrown } from '@/lib/errors/normalize';
+import { presentAppError } from '@/lib/errors/present';
 import ResumeEditSkeleton from './layout/ResumeEditSkeleton';
 import TemplatePanel, { rightPanelWidth } from './templates/TemplatePanel';
 import EditorFormPanel from './layout/EditorFormPanel';
@@ -96,7 +98,10 @@ export default function ResumeEdit({ id }: ResumeEditProps) {
     // agent 是从云端库读简历的，先尽力把编辑器最新状态推上去（关了云同步则无操作）。
     try {
       await syncToCloud();
-    } catch {
+    } catch (err) {
+      // 这一次吞掉的后果不是「少存一次」，而是**agent 接下来读的是旧简历**：它会照着
+      // 过时内容提改动，用户看着自己刚写的段落被改回去。必须说出来。
+      presentAppError(fromThrown(err, 'local'), { surface: 'background' });
     }
     router.push(`/dashboard/edit/${id}/ai-lab`);
   };
@@ -246,6 +251,8 @@ export default function ResumeEdit({ id }: ResumeEditProps) {
       }
     } catch (err) {
       console.error('[Save] Manual save failed:', err);
+      // 用户按了保存按钮，然后什么都没发生——静默在这里就是 bug。
+      presentAppError(fromThrown(err, 'local'), { surface: 'inline' });
     } finally {
       setIsSaving(false);
       console.log('[Save] Manual save process ended, loading state released.');

--- a/apps/web/src/app/dashboard/edit/_components/ai/AiChatShell.tsx
+++ b/apps/web/src/app/dashboard/edit/_components/ai/AiChatShell.tsx
@@ -28,7 +28,9 @@ import LivingCanvas, { type BatchRequest, type FocusRequest } from './canvas/liv
 import { type BatchKind, type TargetedSelectionDiff } from './lib/diffResume';
 import type { MultiPersonaResumeAnalysis } from '@/types/agent/multi-persona';
 import type { FitReport } from '@/types/agent/fit-report';
-import { streamChat, approveTool, endSessionThread, streamPdfParse, type HitlDecision } from './lib/services/agentClient';
+import { streamChat, approveTool, endSessionThread, streamPdfParse, AgentRequestError, type HitlDecision } from './lib/services/agentClient';
+import { fromSseEvent } from '@/lib/errors/normalize';
+import { errorText } from '@/lib/errors/present';
 import type { AgentLlmConfig, AgentSseEvent } from './lib/services/types';
 import {
   invalidateAiEntitlement,
@@ -909,9 +911,9 @@ export default function AiChatShell({
               }
             }
           } else if (ev.type === 'error') {
-            // 后端只发稳定机器码；老部署可能仍发原始上游报错，绝不能让它进对话或 toast。
-            const code = typeof ev.payload?.code === 'string' ? ev.payload.code : ev.error;
-            throw new Error(code || 'agent_run_failed');
+            // 归一化成 AppError 再抛：下游的额度闸门与文案都读码，不再从字符串里往回猜。
+            // 老部署可能仍发原始上游报错，`fromSseEvent` 只取契约字段，原文进不来。
+            throw new AgentRequestError(fromSseEvent(ev));
           }
         }
         if (pausedForApproval && !bubbleCreated) {
@@ -945,7 +947,7 @@ export default function AiChatShell({
           if (pendingOnQuota) pendingRunRef.current = pendingOnQuota;
           setStarted(true);
           setConfigGateOpen(true);
-          const msg = '账户额度不足，已暂停 AI。可以充值/订阅，或配置自定义模型继续。';
+          const msg = errorText(err, aiServiceErrorMessage());
           ensureBubble();
           setMessages((prev) =>
             prev.map((m) => (m.id === aiId ? { ...m, content: acc || `（${msg}）`, status: 'done' } : m))
@@ -957,7 +959,7 @@ export default function AiChatShell({
         setMessages((prev) =>
           prev.map((m) =>
             m.id === aiId
-              ? { ...m, content: acc || `（${aiServiceErrorMessage()}）`, status: 'done' }
+              ? { ...m, content: acc || `（${errorText(err, aiServiceErrorMessage())}）`, status: 'done' }
               : m
           )
         );
@@ -1287,7 +1289,9 @@ export default function AiChatShell({
             if (ev.type === 'resume_update') {
               parsed = ev.data ?? (ev.payload as { resume?: unknown } | undefined)?.resume ?? null;
             } else if (ev.type === 'error' || ev.type === 'run_failed') {
-              throw new Error(ev.error || t('aiLab.attach.failed'));
+              // 「这份 PDF 像是扫描件」这类针对具体文档的解释就在帧的 message 里，
+              // 它进 detail 行；标题永远是本地化的码文案。
+              throw new Error(errorText(fromSseEvent(ev), t('aiLab.attach.failed')));
             }
           }
           const record = (parsed ?? {}) as Record<string, unknown>;

--- a/apps/web/src/app/dashboard/edit/_components/ai/lib/services/agentClient.ts
+++ b/apps/web/src/app/dashboard/edit/_components/ai/lib/services/agentClient.ts
@@ -1,4 +1,6 @@
 import { WEB_AGENT_ROUTES } from '@/lib/api/routes';
+import { fromResponse } from '@/lib/errors/normalize';
+import type { AppError } from '@/lib/errors/types';
 import type { AgentLlmConfig, AgentSseEvent } from './types';
 
 /**
@@ -7,40 +9,24 @@ import type { AgentLlmConfig, AgentSseEvent } from './types';
  */
 
 /**
- * 把上游错误消息映射成用户能行动的友好文案。后端透传的原始字符串
- * （如 `Upstream 'agent' unavailable`、`invalid_api_key`）对用户没有意义，
- * 按状态码 + 关键词归类后再展示；无法归类时回退原始信息。
+ * 把一次失败响应变成可抛的 {@link AgentRequestError}。
+ *
+ * 以前这里是七条按英文散文匹配的正则。它们判错过一次真实故障：BFF 把上游响应整体换成
+ * "Backend request failed with status 429"，正则命中里面那个 "429"，于是「日额度用完」
+ * 被说成「请求过于频繁」，而下游的充值闸门测的是中文串「额度不足」——两边都没命中，
+ * 用户看到一句不相干的话，且没有任何充值入口。
+ *
+ * 现在读码不读字符串。判定只此一处（`fromResponse`），闸门也读同一个码。
  */
-function friendlyAgentError(status: number, raw: string): string {
-  const haystack = `${status} ${raw}`;
-  let friendly = '';
-  if (/timeout|timed out|ETIMEDOUT|abort/i.test(haystack)) {
-    friendly = '请求超时，请检查网络后重试';
-  } else if (/unauthori[sz]ed|forbidden|invalid.*(api.?key|key|token|credential)|authentication|401|403/.test(haystack)) {
-    friendly = 'API Key 无效或没有权限，请检查密钥';
-  } else if (/quota|insufficient.*(balance|credit|quota)|balance|billing|402/.test(haystack)) {
-    friendly = '账户额度不足，请检查余额或配额';
-  } else if (/rate.?limit|too many requests|429/.test(haystack)) {
-    friendly = '请求过于频繁，请稍后重试';
-  } else if (/upstream|origin|gateway|backend.*(unavail|down|error)|502|503/.test(haystack)) {
-    friendly = '服务商上游暂不可用，请稍后重试或检查服务状态';
-  } else if (/not found|no such model|404/.test(haystack)) {
-    friendly = '接口或模型不存在，请检查配置';
-  } else if (status >= 500) {
-    friendly = '服务商返回服务器错误，请稍后重试';
-  }
-  if (!friendly) return raw;
-  return raw && raw !== friendly ? `${friendly}（${raw}）` : friendly;
+async function readError(res: Response): Promise<AgentRequestError> {
+  return new AgentRequestError(await fromResponse(res, 'bff'));
 }
 
-async function readError(res: Response): Promise<string> {
-  try {
-    const data = await res.json();
-    const raw =
-      (data?.error || data?.message || data?.detail || `请求失败（${res.status}）`) as string;
-    return friendlyAgentError(res.status, raw);
-  } catch {
-    return `请求失败（${res.status}）`;
+/** 带上归一化后的 {@link AppError}，让 catch 侧不必再从 message 里往回猜。 */
+export class AgentRequestError extends Error {
+  constructor(readonly appError: AppError) {
+    super(appError.errorCode);
+    this.name = 'AgentRequestError';
   }
 }
 
@@ -49,7 +35,7 @@ async function readError(res: Response): Promise<string> {
  * 遇到非流式错误响应（后端开流前发的 401/422/429）会抛错。
  */
 export async function* consumeSseFrames(res: Response): AsyncGenerator<AgentSseEvent> {
-  if (!res.ok || !res.body) throw new Error(await readError(res));
+  if (!res.ok || !res.body) throw await readError(res);
 
   const reader = res.body.getReader();
   const decoder = new TextDecoder('utf-8');

--- a/apps/web/src/app/dashboard/edit/_components/ai/lib/services/aiAccess.ts
+++ b/apps/web/src/app/dashboard/edit/_components/ai/lib/services/aiAccess.ts
@@ -4,6 +4,7 @@ import {
   invalidateEntitlementCache,
 } from "@/lib/extensions/billing-client";
 import type { Entitlement } from "@/lib/billing/types";
+import { opensBillingGate } from "@/lib/errors/types";
 import type { AgentLlmConfig } from "./types";
 
 export type AiEntitlement = Entitlement;
@@ -121,9 +122,24 @@ function isInconclusive(error: unknown): boolean {
   );
 }
 
+/**
+ * 这次失败该不该把充值/升级入口亮出来。
+ *
+ * 以前它 grep 的是 `friendlyAgentError` 产出的中文串「额度不足」——一个闸门的正确性，
+ * 挂在另一个函数里的四个汉字上：谁把那句国际化成英文，闸门就静默失效，而没有任何测试
+ * 会红。现在读的是码，两边同源（Core ADR-0018）。
+ *
+ * 仍然容忍纯字符串错误：不是所有调用点都已经带上 `AppError`（Clerk、老 catch 分支），
+ * 那些走原来的关键词兜底——但不再依赖任何一种语言的措辞。
+ */
 export function isQuotaOrCustomConfigError(error: unknown) {
+  const appError = (error as { appError?: { errorCode?: unknown } } | null)
+    ?.appError;
+  if (typeof appError?.errorCode === "string") {
+    return opensBillingGate(appError.errorCode as never);
+  }
   const message = error instanceof Error ? error.message : String(error ?? "");
-  return /insufficient_quota|insufficient quota|额度不足|quota|402/i.test(
+  return /quota_exceeded|plan_required|insufficient_quota|insufficient quota|quota|402/i.test(
     message,
   );
 }

--- a/apps/web/src/app/dashboard/edit/_components/ai/lib/services/editClient.ts
+++ b/apps/web/src/app/dashboard/edit/_components/ai/lib/services/editClient.ts
@@ -1,5 +1,7 @@
 import { WEB_AGENT_ROUTES } from '@/lib/api/routes';
 import i18n from '@/i18n';
+import { fromResponse } from '@/lib/errors/normalize';
+import { appErrorText } from '@/lib/errors/present';
 import type { ActionKind } from '../changeModel';
 import type { AgentLlmConfig } from './types';
 
@@ -38,13 +40,16 @@ export interface EditResult {
   rationaleDetail?: string;
 }
 
-async function readError(res: Response): Promise<string> {
-  try {
-    const data = await res.json();
-    return (data?.errorMessage || data?.error || data?.message || data?.detail || `请求失败（${res.status}）`) as string;
-  } catch {
-    return `请求失败（${res.status}）`;
-  }
+/**
+ * 与 `agentClient` 合并成同一条判定路径。
+ *
+ * 两个 readError 此前优先级还不一样：这个先读 `errorMessage`——那正是 BFF 500 时装
+ * undici 内部消息与内网 host 的字段。同一次失败在两个客户端里说两种话，而其中一种
+ * 会把拓扑写到用户屏幕上。
+ */
+async function readError(res: Response): Promise<Error> {
+  const appError = await fromResponse(res, 'bff');
+  return new Error(appErrorText(appError));
 }
 
 /** One-shot snippet/element edit. Throws on transport / empty-result errors. */
@@ -58,7 +63,7 @@ export async function requestEdit({ signal, ...body }: EditParams): Promise<Edit
     body: JSON.stringify({ ...body, locale: isEn ? 'en' : 'zh' }),
     signal,
   });
-  if (!res.ok) throw new Error(await readError(res));
+  if (!res.ok) throw await readError(res);
 
   // Unwrap the useful payload, tolerating a bare `{ after, rationale }` body too.
   const raw = (await res.json()) as

--- a/apps/web/src/app/dashboard/error.tsx
+++ b/apps/web/src/app/dashboard/error.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import { AlertCircle, RotateCcw, LayoutDashboard } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+import { appLifecycle } from '@/lib/extensions/app-lifecycle';
+
+/**
+ * 工作台段级边界。
+ *
+ * 与根级 `app/error.tsx` 的区别是**用户不会丢掉上下文**：侧栏和路由都还在，崩的只是这一
+ * 段。此前工作台里任何一次渲染崩溃都会一路冒到根边界，把整屏换成一张全页错误卡——一次
+ * 组件级的 bug 被呈现成整个应用挂了。
+ */
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    console.error('Dashboard boundary caught:', error);
+    appLifecycle.reactErrorCaught({
+      message: error.message,
+      name: error.name,
+      stack: error.stack,
+      digest: error.digest,
+      component: 'app/dashboard',
+    });
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-6 p-8 text-center">
+      <div className="flex h-14 w-14 items-center justify-center rounded-full bg-red-500/10">
+        <AlertCircle className="h-7 w-7 text-red-500" />
+      </div>
+      <div className="space-y-2">
+        <h2 className="text-xl font-semibold">{t('errorPage.title')}</h2>
+        <p className="max-w-md text-sm leading-relaxed text-neutral-400">
+          {t('errors.internal_error')}
+        </p>
+      </div>
+      <div className="flex flex-col items-center gap-3 sm:flex-row">
+        <Button onClick={() => reset()} className="gap-2">
+          <RotateCcw className="h-4 w-4" />
+          {t('errorPage.buttons.tryAgain')}
+        </Button>
+        <Link href="/dashboard">
+          <Button variant="outline" className="gap-2">
+            <LayoutDashboard className="h-4 w-4" />
+            {t('sidebar.resumes')}
+          </Button>
+        </Link>
+      </div>
+      {error.digest && (
+        <p className="text-[11px] text-neutral-600">{error.digest}</p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useEffect } from 'react';
+import { appLifecycle } from '@/lib/extensions/app-lifecycle';
+
+/**
+ * 根布局自己崩了的时候。
+ *
+ * `app/error.tsx` 接不住这一层——它在 layout 内部渲染，而 layout 已经不在了。此前这一档
+ * 完全空缺：Provider 树（Clerk、i18n、主题）里任何一个抛异常，用户拿到的是一块纯白屏，
+ * 而我们这边一个数都没有。
+ *
+ * 这里不能用 i18n、不能用设计系统组件——它们正是可能已经挂掉的东西。所以文案内联双语，
+ * 样式内联，依赖只有 React 本身。丑一点没关系，能出现就是全部意义。
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('Root layout crashed:', error);
+    appLifecycle.reactErrorCaught({
+      message: error.message,
+      name: error.name,
+      stack: error.stack,
+      digest: error.digest,
+      component: 'root',
+    });
+  }, [error]);
+
+  return (
+    <html lang="zh-CN">
+      <body
+        style={{
+          margin: 0,
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: '#0A0A0A',
+          color: '#e5e5e5',
+          fontFamily:
+            'system-ui, -apple-system, "Segoe UI", "PingFang SC", sans-serif',
+          padding: 24,
+        }}
+      >
+        <div style={{ maxWidth: 420, textAlign: 'center' }}>
+          <h1 style={{ fontSize: 20, fontWeight: 600, margin: '0 0 12px' }}>
+            页面加载失败{/* i18n-ignore */}
+          </h1>
+          <p
+            style={{
+              fontSize: 14,
+              lineHeight: 1.6,
+              color: '#a3a3a3',
+              margin: '0 0 8px',
+            }}
+          >
+            出了点问题，我们已经收到告警。刷新一下通常就好了。{/* i18n-ignore */}
+          </p>
+          <p
+            style={{
+              fontSize: 13,
+              lineHeight: 1.6,
+              color: '#737373',
+              margin: '0 0 24px',
+            }}
+          >
+            Something went wrong. We&apos;ve been alerted — reloading usually fixes it.{/* i18n-ignore */}
+          </p>
+          <button
+            onClick={() => reset()}
+            style={{
+              padding: '10px 20px',
+              borderRadius: 8,
+              border: 'none',
+              background: '#fff',
+              color: '#000',
+              fontSize: 14,
+              fontWeight: 500,
+              cursor: 'pointer',
+            }}
+          >
+            重新加载 · Reload{/* i18n-ignore：这一档不能依赖 i18n，它可能正是崩掉的那个 */}
+          </button>
+          {error.digest && (
+            <p style={{ fontSize: 11, color: '#525252', marginTop: 16 }}>
+              {error.digest}
+            </p>
+          )}
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -20,6 +20,7 @@ import PreloadOptimizer from "@/components/shared/PreloadOptimizer";
 import StructuredData from "@/components/shared/StructuredData";
 import I18nProvider from "@/components/providers/I18nProvider";
 import { HttpClientProvider } from "@/components/providers/HttpClientProvider";
+import { GlobalErrorListener } from "@/components/providers/GlobalErrorListener";
 import { CommercialRuntimeProvider } from "@/lib/commercial/runtime";
 import { RuntimeEnvScript } from "@/lib/commercial/runtime-env";
 import { CloudAuthBridge } from "@/lib/auth";
@@ -66,6 +67,9 @@ export default function RootLayout({
                   bundle reads it. Kept OUT of CommercialRuntimeProvider because
                   the commercial overlay replaces that module — see runtime-env.tsx. */}
               <RuntimeEnvScript />
+              {/* window.onerror / unhandledrejection 的唯一汇聚点。挂在最外层，因为
+                  它要能收到 Provider 树自己抛出来的东西。 */}
+              <GlobalErrorListener />
               <CommercialRuntimeProvider>
                 <I18nProvider>
                   <ThemeProvider>

--- a/apps/web/src/components/providers/GlobalErrorListener.tsx
+++ b/apps/web/src/components/providers/GlobalErrorListener.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useEffect } from 'react';
+import { appLifecycle } from '@/lib/extensions/app-lifecycle';
+
+/**
+ * `window.onerror` 与 `unhandledrejection` 的汇聚点。
+ *
+ * 这两个此前**一个都没有挂**。React 边界只接得住渲染期的崩溃；事件回调里抛的异常、
+ * 没有 `.catch()` 的 promise、第三方脚本的报错，全部只在用户自己的控制台里闪一下——
+ * 也就是说，最难复现的那类故障，恰好是我们唯一收不到的那类。
+ *
+ * 只上报，不弹提示：到得了这里的东西通常已经有别的地方在处理，再弹一层只会重复打扰。
+ */
+export function GlobalErrorListener() {
+  useEffect(() => {
+    const onError = (event: ErrorEvent) => {
+      console.error('[window.onerror]', event.message, event.error);
+      appLifecycle.reactErrorCaught({
+        message: event.message || 'Unhandled error',
+        name: (event.error as Error | undefined)?.name,
+        stack: (event.error as Error | undefined)?.stack,
+        component: 'window',
+      });
+    };
+
+    const onRejection = (event: PromiseRejectionEvent) => {
+      const reason = event.reason as unknown;
+      // 用户点了停止/关了弹窗会走到这里，那不是故障。
+      if ((reason as { name?: string })?.name === 'AbortError') return;
+      console.error('[unhandledrejection]', reason);
+      appLifecycle.reactErrorCaught({
+        message:
+          reason instanceof Error ? reason.message : String(reason ?? 'unknown'),
+        name: reason instanceof Error ? reason.name : 'UnhandledRejection',
+        stack: reason instanceof Error ? reason.stack : undefined,
+        component: 'promise',
+      });
+    };
+
+    window.addEventListener('error', onError);
+    window.addEventListener('unhandledrejection', onRejection);
+    return () => {
+      window.removeEventListener('error', onError);
+      window.removeEventListener('unhandledrejection', onRejection);
+    };
+  }, []);
+
+  return null;
+}

--- a/apps/web/src/lib/api/httpClient.ts
+++ b/apps/web/src/lib/api/httpClient.ts
@@ -1,6 +1,8 @@
 import axios, { AxiosInstance, AxiosError } from 'axios';
 import { API_ORIGIN } from './routes';
 import { appLifecycle } from '@/lib/extensions/app-lifecycle';
+import { fromAxiosError } from '@/lib/errors/normalize';
+import type { AppError } from '@/lib/errors/types';
 
 // Mutable getter — set once by HttpClientProvider at app startup
 let _getToken: (() => Promise<string | null>) | null = null;
@@ -48,10 +50,21 @@ const createClient = (baseURL: string): AxiosInstance => {
   client.interceptors.response.use(
     (response) => response,
     (error: AxiosError) => {
+      // 归一化后挂回错误对象上：调用方的 catch 因此能读码，而不必再解一遍响应体。
+      // 这是全应用唯一一个已经存在的 HTTP 汇聚点，判定放在这里只此一处。
+      const appError = fromAxiosError(error);
+      (error as AxiosError & { appError?: AppError }).appError = appError;
+
       if (error.response) {
-        console.error('API Error:', error.response.status, error.response.data);
+        console.error(
+          'API Error:',
+          error.response.status,
+          appError.errorCode,
+          appError.subCode ?? '',
+          appError.requestId ?? ''
+        );
       } else if (error.request) {
-        console.error('Network Error:', error.message);
+        console.error('Network Error:', appError.errorCode, error.message);
       } else {
         console.error('Request Error:', error.message);
       }

--- a/apps/web/src/lib/errors/message.ts
+++ b/apps/web/src/lib/errors/message.ts
@@ -1,0 +1,144 @@
+import type { AppError, AppErrorCodeOrUnknown, AppErrorParams } from './types';
+
+export interface AppErrorCopy {
+  /** 已本地化的主句。**永远有值**，且永远是本地语言。 */
+  title: string;
+  /** 服务端针对这一次失败写的补充说明。语言不保证，所以只能挂在 title 下面。 */
+  detail?: string;
+}
+
+type Translate = (
+  key: string,
+  options?: Record<string, unknown>,
+) => string;
+
+/**
+ * 码 → 这次失败该显示的话。
+ *
+ * 文案归前端（ADR-0018）：这个产品里语言是客户端运行时开关（`setPreferredLanguage` 只调
+ * `changeLanguage`，不刷新也不重发请求），而 agent 的错误会进聊天记录并持久化——服务端
+ * 本地化的串会留下一份永远改不回来的中英混排会话历史。
+ *
+ * 顺序与旧的 `agentErrorMessage` 相反：以前服务端句子直接当正文，于是「写给运营的英文」
+ * 被拿去给买家看。现在本地化的码文案永远当标题，服务端那句降为补充行——屏幕上因此
+ * 永远不会只剩一句外语。
+ */
+export function appErrorCopy(error: AppError, t: Translate): AppErrorCopy {
+  const title = translateCode(error.errorCode, error.params, t);
+  const detail = error.publicMessage?.trim();
+  return { title, ...(detail && detail !== title ? { detail } : {}) };
+}
+
+/** 单行版本：给 toast 和聊天气泡这种放不下两行的地方。 */
+export function appErrorMessage(error: AppError, t: Translate): string {
+  const { title, detail } = appErrorCopy(error, t);
+  return detail ? `${title}（${detail}）` : title;
+}
+
+function translateCode(
+  code: AppErrorCodeOrUnknown,
+  params: AppErrorParams | undefined,
+  t: Translate,
+): string {
+  const values = interpolationValues(params, t);
+
+  // key 阶梯：先试按 subject/rule 细化的那条，再退到码本身。13 个码靠 params 细化出
+  // 几十句文案，而不是靠往封闭表里加码。
+  const refinement =
+    typeof params?.rule === 'string'
+      ? params.rule
+      : typeof params?.subject === 'string'
+        ? params.subject
+        : undefined;
+  if (refinement) {
+    const refined = lookup(`errors.${code}.${refinement}`, values, t);
+    if (refined) return refined;
+  }
+
+  // `errors.<code>` 必然存在——`app.test.ts` 里有一条覆盖测试钉着它。
+  return (
+    lookup(`errors.${code}`, values, t) ??
+    lookup('errors.unknown', values, t) ??
+    'Something went wrong'
+  );
+}
+
+/**
+ * i18next 在缺 key 时会返回 key 本身，所以 `copy === key` 也算「没有文案」。
+ *
+ * 这条来之不易：正是它缺席的时候，用户屏幕上出现了 `agentErrors.agent_run_failed`——
+ * 比原始码更糟。
+ */
+function lookup(
+  key: string,
+  values: Record<string, unknown>,
+  t: Translate,
+): string | undefined {
+  const copy = t(key, { ...values, defaultValue: '' });
+  return copy && copy !== key ? copy : undefined;
+}
+
+/**
+ * params → 可插值的值。
+ *
+ * 时间在这里按 locale 渲染成相对说法：后端不知道用户的时区，也不知道他此刻把语言切成了
+ * 什么——这正是「参数后端、文案前端」这条分界买来的东西。
+ */
+function interpolationValues(
+  params: AppErrorParams | undefined,
+  t: Translate,
+): Record<string, unknown> {
+  if (!params) return {};
+  const values: Record<string, unknown> = { ...params };
+
+  if (typeof params.resetAt === 'string') {
+    const relative = relativeTime(params.resetAt);
+    if (relative) values.resetAt = relative;
+  }
+  if (typeof params.retryAfterSec === 'number') {
+    values.retryAfter = formatSeconds(params.retryAfterSec, t);
+  }
+  if (typeof params.period === 'string') {
+    values.period = t(`errors.period.${params.period}`, {
+      defaultValue: params.period,
+    });
+  }
+  return values;
+}
+
+function relativeTime(iso: string): string | undefined {
+  const target = new Date(iso).getTime();
+  if (!Number.isFinite(target)) return undefined;
+  const deltaMs = target - Date.now();
+  const minutes = Math.round(deltaMs / 60_000);
+  const language = resolveLanguage();
+  try {
+    const formatter = new Intl.RelativeTimeFormat(language, {
+      numeric: 'auto',
+    });
+    if (Math.abs(minutes) < 60) return formatter.format(minutes, 'minute');
+    const hours = Math.round(minutes / 60);
+    if (Math.abs(hours) < 24) return formatter.format(hours, 'hour');
+    return formatter.format(Math.round(hours / 24), 'day');
+  } catch {
+    return undefined;
+  }
+}
+
+function formatSeconds(seconds: number, t: Translate): string {
+  const safe = Math.max(1, Math.ceil(seconds));
+  if (safe < 60) return t('errors.duration.seconds', { count: safe, defaultValue: `${safe}s` });
+  const minutes = Math.ceil(safe / 60);
+  return t('errors.duration.minutes', {
+    count: minutes,
+    defaultValue: `${minutes}min`,
+  });
+}
+
+/** SSR 与测试里没有 navigator；`undefined` 会让 Intl 用运行时默认 locale。 */
+function resolveLanguage(): string | undefined {
+  if (typeof document !== 'undefined' && document.documentElement.lang) {
+    return document.documentElement.lang;
+  }
+  return undefined;
+}

--- a/apps/web/src/lib/errors/normalize.ts
+++ b/apps/web/src/lib/errors/normalize.ts
@@ -1,0 +1,239 @@
+import {
+  codeForStatus,
+  codeFromLegacy,
+  isAppErrorCode,
+  isRetryable,
+  type AppError,
+  type AppErrorCodeOrUnknown,
+  type AppErrorParams,
+  type AppErrorSource,
+} from './types';
+
+/**
+ * 把各个汇聚点抛出来的东西归一成 {@link AppError}。全是纯函数——它们的正确性就是整套
+ * 错误层的地基，必须能被逐条断言。
+ *
+ * 关键的一条不是「新后端发了码」，而是**上游什么都没发时怎么办**：老后端还在线上时，
+ * 前端手里只有一个状态码。那条降级路径要当一等公民对待，不是兜底。
+ */
+
+interface RawErrorBody {
+  errorCode?: unknown;
+  subCode?: unknown;
+  params?: unknown;
+  requestId?: unknown;
+  retryable?: unknown;
+  code?: unknown;
+  message?: unknown;
+  /** 老 BFF 的字段，正在退役——它会把 undici 内部与内网 host 泄漏出来。 */
+  errorMessage?: unknown;
+  error?: unknown;
+  detail?: unknown;
+}
+
+function asRecord(value: unknown): RawErrorBody {
+  return typeof value === 'object' && value !== null
+    ? (value as RawErrorBody)
+    : {};
+}
+
+function readParams(value: unknown): AppErrorParams | undefined {
+  if (typeof value !== 'object' || value === null) return undefined;
+  const out: AppErrorParams = {};
+  for (const [key, raw] of Object.entries(value as Record<string, unknown>)) {
+    if (
+      typeof raw === 'string' ||
+      typeof raw === 'number' ||
+      typeof raw === 'boolean'
+    ) {
+      out[key] = raw;
+    } else if (Array.isArray(raw) && raw.every((v) => typeof v === 'string')) {
+      out[key] = raw as string[];
+    }
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * 服务端刻意写给人看的那句话。
+ *
+ * 只认 `message`：`errorMessage` / `error` / `detail` 是老 BFF 与老 readError 的遗产，
+ * 里面装的是 `Backend request failed with status 429` 和 undici 的内部消息——把它们当
+ * 文案渲染，正是「用户被告知你太快了」这个 bug 的最后一环。
+ */
+function readPublicMessage(body: RawErrorBody): string | undefined {
+  const raw = body.message;
+  if (typeof raw !== 'string') return undefined;
+  const text = raw.trim();
+  if (!text) return undefined;
+  // `message` 也可能只是个机器码（老信封在没有 message 时会退回 code）——那不是文案。
+  if (codeFromLegacy(text) || isAppErrorCode(text)) return undefined;
+  return text;
+}
+
+/** 从任意错误响应体里读出契约字段；上游没发就按状态合成。 */
+export function fromErrorBody(
+  status: number | undefined,
+  rawBody: unknown,
+  source: AppErrorSource,
+  cause?: unknown,
+): AppError {
+  const body = asRecord(rawBody);
+
+  const errorCode: AppErrorCodeOrUnknown = isAppErrorCode(body.errorCode)
+    ? body.errorCode
+    : (codeFromLegacy(body.code) ??
+      (typeof status === 'number' ? codeForStatus(status) : 'unknown'));
+
+  const publicMessage = readPublicMessage(body);
+
+  return {
+    errorCode,
+    ...(typeof body.subCode === 'string' && body.subCode
+      ? { subCode: body.subCode }
+      : typeof body.code === 'string' && body.code !== errorCode
+        ? { subCode: body.code }
+        : {}),
+    ...(readParams(body.params) ? { params: readParams(body.params) } : {}),
+    ...(typeof status === 'number' ? { httpStatus: status } : {}),
+    ...(typeof body.requestId === 'string' && body.requestId
+      ? { requestId: body.requestId }
+      : {}),
+    // 上游的 `retryable` 优先——它知道自己那次失败是不是暂时的；否则按码查表。
+    retryable:
+      typeof body.retryable === 'boolean'
+        ? body.retryable
+        : isRetryable(errorCode),
+    ...(publicMessage ? { publicMessage } : {}),
+    source,
+    ...(cause !== undefined ? { cause } : {}),
+  };
+}
+
+/** fetch 的 `Response`。会把体读掉，所以只在确定不再需要它时调用。 */
+export async function fromResponse(
+  response: Response,
+  source: AppErrorSource = 'bff',
+): Promise<AppError> {
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    body = undefined;
+  }
+  return fromErrorBody(response.status, body, source);
+}
+
+/** axios 的错误。网络失败/超时/取消没有响应，走 {@link fromThrown} 的同一套判断。 */
+export function fromAxiosError(error: unknown): AppError {
+  const axiosError = error as {
+    response?: { status?: number; data?: unknown };
+    request?: unknown;
+    code?: unknown;
+    message?: unknown;
+  };
+  if (axiosError?.response) {
+    return fromErrorBody(
+      axiosError.response.status,
+      axiosError.response.data,
+      'http',
+      error,
+    );
+  }
+  return fromThrown(error, 'http');
+}
+
+/**
+ * agent 的 SSE 错误帧。
+ *
+ * 帧里 `error` 与 `payload.code` 是同一个码的两处冗余（老客户端读 `error`），任取其一即可；
+ * 新增的 `payload.errorCode` 优先。
+ */
+export function fromSseEvent(event: {
+  error?: unknown;
+  payload?: unknown;
+}): AppError {
+  const payload = asRecord(event.payload);
+  const merged: RawErrorBody = {
+    ...payload,
+    code: payload.code ?? event.error,
+  };
+  return fromErrorBody(undefined, merged, 'sse');
+}
+
+/**
+ * 任何被 throw 出来的东西：网络断了、请求被取消、代码抛了个 TypeError。
+ *
+ * 这条路径上根本没有后端 message——**这正是「前端必须自己有一张码→文案表」的原因**，
+ * 与后端要不要做 i18n 无关。
+ */
+export function fromThrown(
+  error: unknown,
+  source: AppErrorSource = 'local',
+): AppError {
+  const name = (error as { name?: unknown })?.name;
+  const code = (error as { code?: unknown })?.code;
+
+  // 用户自己点了停止/关了弹窗。这不是故障，调用方通常应当直接丢弃。
+  if (name === 'AbortError' || name === 'CanceledError' || code === 'ERR_CANCELED') {
+    return {
+      errorCode: 'unknown',
+      subCode: 'aborted',
+      retryable: false,
+      source,
+      cause: error,
+    };
+  }
+
+  // 连不上、DNS 挂了、超时。是依赖够不着，不是「我们有 bug」。
+  if (
+    name === 'TypeError' ||
+    code === 'ECONNABORTED' ||
+    code === 'ETIMEDOUT' ||
+    code === 'ERR_NETWORK'
+  ) {
+    return {
+      errorCode: 'upstream_unavailable',
+      subCode: 'network',
+      retryable: true,
+      source,
+      cause: error,
+    };
+  }
+
+  return {
+    errorCode: 'internal_error',
+    retryable: false,
+    source,
+    cause: error,
+  };
+}
+
+/** 这次失败是「用户主动取消」——调用方据此静默丢弃，不弹提示。 */
+export function isAborted(error: AppError): boolean {
+  return error.subCode === 'aborted';
+}
+
+/**
+ * Clerk 的错误。**刻意不并进主码表**：Clerk 有自己的封闭词表和 `longMessage` 兜底，
+ * 而映射错比不映射更糟——把「验证码过期」说成「验证码错误」，用户会一直重输同一个码。
+ * 它只共享 `AppError` 的形状与渲染器。
+ */
+export function fromClerkError(error: unknown, fallback: string): AppError {
+  const clerk = error as {
+    errors?: { code?: unknown; longMessage?: unknown; message?: unknown }[];
+  };
+  const first = Array.isArray(clerk?.errors) ? clerk.errors[0] : undefined;
+  const authored =
+    (typeof first?.longMessage === 'string' && first.longMessage) ||
+    (typeof first?.message === 'string' && first.message) ||
+    fallback;
+  return {
+    errorCode: 'invalid_input',
+    ...(typeof first?.code === 'string' ? { subCode: first.code } : {}),
+    retryable: false,
+    publicMessage: authored,
+    source: 'local',
+    cause: error,
+  };
+}

--- a/apps/web/src/lib/errors/present.ts
+++ b/apps/web/src/lib/errors/present.ts
@@ -1,0 +1,126 @@
+import { toast } from 'sonner';
+import i18n from '@/i18n';
+import { appErrorCopy, appErrorMessage } from './message';
+import { isAborted } from './normalize';
+import { opensBillingGate, type AppError } from './types';
+
+/**
+ * 一次失败该怎么出现在屏幕上。
+ *
+ * 抽成单一决策点，是因为此前这件事分散在 66 个各写各的 toast 调用点上——同一个码在两处
+ * 是两种表现，而三处最痛的失败（手动保存失败、开 AI 前的同步失败、SSE 帧解析失败）
+ * 干脆只 `console.error` 了事：用户按了按钮，然后什么都没发生。
+ */
+export type ErrorSurface =
+  /** 对话流里的一条消息。agent 相关的失败用它，因为它会留在会话记录里。 */
+  | 'chat'
+  /** 就地提示：用户刚点的那个按钮旁边。 */
+  | 'inline'
+  /** 整页级：这一屏没法继续了。 */
+  | 'page'
+  /** 后台失败：用户没在等它，但状态已经不对了。 */
+  | 'background';
+
+export interface PresentOptions {
+  surface?: ErrorSurface;
+  /** 可重试且调用方给得出重试动作时，提示上会带一个按钮。 */
+  onRetry?: () => void;
+  /** 额度/套餐类失败的去处，通常是打开充值弹窗。 */
+  onUpgrade?: () => void;
+}
+
+export interface PresentedError {
+  title: string;
+  detail?: string;
+  /** 该不该把充值/升级入口亮出来。读的是码，不是中文串。 */
+  billingGate: boolean;
+  retryable: boolean;
+}
+
+/**
+ * 渲染一次失败，并返回渲染决策（调用方要自己接管 UI 时可以只取返回值）。
+ *
+ * 用户主动取消不是故障：静默丢弃，不弹任何东西。
+ */
+export function presentAppError(
+  error: AppError,
+  options: PresentOptions = {},
+): PresentedError | null {
+  if (isAborted(error)) return null;
+
+  const t = i18n.t.bind(i18n);
+  const { title, detail } = appErrorCopy(error, t);
+  const billingGate = opensBillingGate(error.errorCode);
+  const decision: PresentedError = {
+    title,
+    ...(detail ? { detail } : {}),
+    billingGate,
+    retryable: error.retryable,
+  };
+
+  reportToConsole(error, title);
+
+  const surface = options.surface ?? 'inline';
+  // 对话流由调用方自己插消息——它要进会话记录，不是一闪而过的提示。
+  if (surface === 'chat') return decision;
+
+  const action = billingGate && options.onUpgrade
+    ? {
+        label: t('errors.actions.upgrade', { defaultValue: '去充值' }),
+        onClick: options.onUpgrade,
+      }
+    : error.retryable && options.onRetry
+      ? {
+          label: t('errors.actions.retry', { defaultValue: '重试' }),
+          onClick: options.onRetry,
+        }
+      : undefined;
+
+  toast.error(title, {
+    ...(detail ? { description: detail } : {}),
+    ...(action ? { action } : {}),
+    // 后台失败用户没在等，别抢焦点；整页级的要停久一点。
+    duration: surface === 'background' ? 4000 : surface === 'page' ? 10000 : 6000,
+  });
+
+  return decision;
+}
+
+/** 只渲染文案、不弹提示——聊天气泡与行内错误位用它。 */
+export function appErrorText(error: AppError): string {
+  return appErrorMessage(error, i18n.t.bind(i18n));
+}
+
+/**
+ * 任意抛出值 → 一句能给人看的话。
+ *
+ * 收敛期的桥：不是每个 catch 都已经拿到 `AppError`。带码的走契约，剩下的用调用方给的
+ * 兜底句——**绝不把 `error.message` 直接渲染出去**，那正是 `agent_run_failed` 和
+ * "Backend request failed with status 429" 上过屏幕的原因。
+ */
+export function errorText(error: unknown, fallback: string): string {
+  const carried = (error as { appError?: AppError } | null)?.appError;
+  if (carried?.errorCode) return appErrorText(carried);
+  if (isAppErrorShaped(error)) return appErrorText(error);
+  return fallback;
+}
+
+function isAppErrorShaped(value: unknown): value is AppError {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as AppError).errorCode === 'string' &&
+    typeof (value as AppError).source === 'string'
+  );
+}
+
+/**
+ * 诊断信息写控制台。`subCode` 与 `requestId` 永远不渲染给用户，但它们正是排查时唯一
+ * 有用的东西——用户截个图就能把 requestId 给我们。
+ */
+function reportToConsole(error: AppError, title: string) {
+  const parts = [error.errorCode, error.subCode, error.requestId].filter(
+    Boolean,
+  );
+  console.warn(`[error] ${parts.join(' · ')} — ${title}`, error.cause ?? '');
+}

--- a/apps/web/src/lib/errors/types.ts
+++ b/apps/web/src/lib/errors/types.ts
@@ -1,0 +1,150 @@
+/**
+ * 前端这一侧的错误契约（Core ADR-0018）。
+ *
+ * 刻意是**独立的一份**，不从后端包里引：两个仓分别发版，任何一刻都可能是「新前端 + 老后端」
+ * 或反过来。共享一份类型只会把版本偏斜变成构建失败，而这里真正需要的是偏斜时优雅降级——
+ * 靠的是下面那张 `codeForStatus` 兜底表，它必须与后端逐条一致。
+ */
+export const APP_ERROR_CODES = [
+  'unauthenticated',
+  'forbidden',
+  'plan_required',
+  'not_found',
+  'invalid_input',
+  'conflict',
+  'session_invalid',
+  'quota_exceeded',
+  'rate_limited',
+  'content_rejected',
+  'upstream_unavailable',
+  'misconfigured',
+  'internal_error',
+] as const;
+
+export type AppErrorCode = (typeof APP_ERROR_CODES)[number];
+
+/** 后端发了一个我们不认识的码——即「新后端 + 老前端」。文案退到通用兜底。 */
+export type AppErrorCodeOrUnknown = AppErrorCode | 'unknown';
+
+export type AppErrorParamValue = string | number | boolean | readonly string[];
+export type AppErrorParams = Record<string, AppErrorParamValue>;
+
+/** 这次失败是从哪个汇聚点进来的。只用于上报与调试，不影响文案。 */
+export type AppErrorSource =
+  | 'http'
+  | 'sse'
+  | 'bff'
+  | 'react'
+  | 'window'
+  | 'local';
+
+export interface AppError {
+  errorCode: AppErrorCodeOrUnknown;
+  /** 高基数二级码。**只进上报，永不渲染**。 */
+  subCode?: string;
+  params?: AppErrorParams;
+  httpStatus?: number;
+  requestId?: string;
+  retryable: boolean;
+  /** 服务端刻意写给人看的补充句。语言不保证，所以只能当 detail 行，永不单独成句。 */
+  publicMessage?: string;
+  source: AppErrorSource;
+  /** 仅开发期诊断用，永不渲染给用户。 */
+  cause?: unknown;
+}
+
+export function isAppErrorCode(value: unknown): value is AppErrorCode {
+  return (
+    typeof value === 'string' &&
+    (APP_ERROR_CODES as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * 没有 `errorCode` 时由 HTTP 状态合成。
+ *
+ * **必须与后端 `@magic/util` 的同名函数逐条一致**：「老后端 + 新前端」会长期存在，那时这张表
+ * 就是全部的判据；两边分歧会让同一次失败在两侧被归成两个码。
+ *
+ * 429 落 `rate_limited` 而不是 `quota_exceeded`：额度必须由上游显式发码。猜是猜不对的——
+ * 这正是本次要修的那个 bug 的成因。
+ */
+export function codeForStatus(status: number): AppErrorCode {
+  switch (status) {
+    case 400:
+    case 413:
+    case 415:
+    case 422:
+      return 'invalid_input';
+    case 401:
+      return 'unauthenticated';
+    case 402:
+      return 'quota_exceeded';
+    case 403:
+      return 'forbidden';
+    case 404:
+      return 'not_found';
+    case 409:
+      return 'conflict';
+    case 410:
+      return 'session_invalid';
+    case 429:
+      return 'rate_limited';
+    case 408:
+    case 502:
+    case 503:
+    case 504:
+      return 'upstream_unavailable';
+    default:
+      return status >= 500 ? 'internal_error' : 'invalid_input';
+  }
+}
+
+/**
+ * 存量字符串码 → 一级码。上游还没升级完的那几周，这张表就是全部的可用信息。
+ * 与后端 `codeFromLegacy` 同一份。
+ */
+const LEGACY_CODE_ALIASES: Readonly<Record<string, AppErrorCode>> = {
+  quota_exhausted: 'quota_exceeded',
+  insufficient_quota: 'quota_exceeded',
+  rate_limit_exceeded: 'rate_limited',
+  invalid_api_key: 'unauthenticated',
+  model_not_allowed: 'forbidden',
+  model_not_found: 'invalid_input',
+  model_unavailable: 'upstream_unavailable',
+  upstream_error: 'upstream_unavailable',
+  entitlement_unavailable: 'internal_error',
+  billing_operation_in_progress: 'conflict',
+  agent_run_failed: 'internal_error',
+};
+
+export function codeFromLegacy(value: unknown): AppErrorCode | undefined {
+  if (typeof value !== 'string') return undefined;
+  if (isAppErrorCode(value)) return value;
+  return LEGACY_CODE_ALIASES[value];
+}
+
+/**
+ * 值不值得重试。
+ *
+ * 只有这两个为 true。以前 SSE 帧里是硬编码的 `retryable: true`，对「余额不足」也说 true——
+ * 客户端于是去重试一个永远不会成功的请求，每次还占掉一次配额预留。
+ */
+const RETRYABLE_CODES = new Set<string>([
+  'rate_limited',
+  'upstream_unavailable',
+]);
+
+export function isRetryable(code: AppErrorCodeOrUnknown): boolean {
+  return RETRYABLE_CODES.has(code);
+}
+
+/**
+ * 这两个码要额外打开充值/升级入口。
+ *
+ * 以前这个判断靠 grep 另一个函数产出的中文串「额度不足」——谁把那句国际化成英文，闸门就
+ * 静默失效。现在它读码。
+ */
+export function opensBillingGate(code: AppErrorCodeOrUnknown): boolean {
+  return code === 'quota_exceeded' || code === 'plan_required';
+}

--- a/apps/web/src/locales/en/translation.json
+++ b/apps/web/src/locales/en/translation.json
@@ -2028,5 +2028,34 @@
     "iconLabel": "Icon (optional)",
     "deleteTitle": "Delete section",
     "deleteHint": "\"{{name}}\" and everything in it will be deleted. This cannot be undone."
+  },
+  "errors": {
+    "unauthenticated": "Your session expired. Sign in again to continue.",
+    "forbidden": "This account can't do that.",
+    "plan_required": "Your plan doesn't include this yet — upgrade to continue.",
+    "not_found": "We couldn't find that. It may have been deleted.",
+    "invalid_input": "Something you entered isn't valid. Check it and try again.",
+    "conflict": "Something else changed just now. Refresh and try again.",
+    "session_invalid": "This conversation has expired. Start a new one to continue.",
+    "quota_exceeded": "You've used up this {{period}}'s allowance. It resets {{resetAt}} — or upgrade your plan, or use your own model key.",
+    "rate_limited": "Too many requests. Try again in {{retryAfter}}.",
+    "content_rejected": "That content didn't pass review. Try rephrasing, or use a different file.",
+    "upstream_unavailable": "The service is temporarily unavailable. Try again shortly.",
+    "misconfigured": "This feature is temporarily unavailable. We've been alerted.",
+    "internal_error": "Something went wrong on our side. We've been alerted.",
+    "unknown": "Something went wrong. Please try again.",
+    "period": {
+      "daily": "day",
+      "weekly": "week",
+      "monthly": "month"
+    },
+    "duration": {
+      "seconds": "{{count}}s",
+      "minutes": "{{count}} min"
+    },
+    "actions": {
+      "retry": "Retry",
+      "upgrade": "Add credits"
+    }
   }
 }

--- a/apps/web/src/locales/zh/translation.json
+++ b/apps/web/src/locales/zh/translation.json
@@ -2028,5 +2028,34 @@
     "iconLabel": "图标（可选）",
     "deleteTitle": "删除模块",
     "deleteHint": "「{{name}}」及其中的条目会一并删除，此操作无法撤销。"
+  },
+  "errors": {
+    "unauthenticated": "登录已过期，请重新登录后继续。",
+    "forbidden": "这个账号没有权限做这件事。",
+    "plan_required": "当前套餐还用不了这个能力，升级后即可继续。",
+    "not_found": "没找到这个内容，它可能已经被删除了。",
+    "invalid_input": "填写的内容有问题，请检查后重试。",
+    "conflict": "刚才有另一处改动，请刷新后重试。",
+    "session_invalid": "这段对话已经失效了，开一段新的继续。",
+    "quota_exceeded": "本{{period}}额度已用完，{{resetAt}}恢复；也可以升级套餐或用自己的模型 Key。",
+    "rate_limited": "请求太密集了，{{retryAfter}}后再试。",
+    "content_rejected": "这份内容没能通过审核，换个说法或换份文件再试。",
+    "upstream_unavailable": "服务暂时不可用，稍后再试一次。",
+    "misconfigured": "这个功能暂时不可用，我们已经收到告警。",
+    "internal_error": "出了点问题，我们已经收到告警。",
+    "unknown": "出了点问题，请稍后重试。",
+    "period": {
+      "daily": "日",
+      "weekly": "周",
+      "monthly": "月"
+    },
+    "duration": {
+      "seconds": "{{count}} 秒",
+      "minutes": "{{count}} 分钟"
+    },
+    "actions": {
+      "retry": "重试",
+      "upgrade": "去充值"
+    }
   }
 }


### PR DESCRIPTION
> **base 是 #196 的分支**，因为本 PR 在 `AiChatShell.tsx` 与 `app.test.ts` 上接着它改。#196 合并后 GitHub 会自动把这条重定向到 master。

配套后端：Magic-Core#156（ADR-0018）。两边可以独立合——本 PR 对「老后端」有降级路径且有测试钉着。

## 为什么

前端此前有 **6 张互不引用的错误映射表**、66 个各写各的 toast 调用点，并且**没有** `global-error.tsx`、没有段级 error boundary、没有 `window.onerror`、没有 `unhandledrejection`——最难复现的那类故障，恰好是我们唯一收不到的那类。

生产上这条链是这么断的：

```
日额度用完 → 后端 429
  → BFF 整体替换成 "Backend request failed with status 429"
  → agentClient 的正则命中里面那个 "429" → 「请求过于频繁，请稍后重试」
  → 而 isQuotaOrCustomConfigError 测的是中文串「额度不足」→ 不命中
```

用户额度用完，被告知你太快了，且**没有任何充值入口**。

## 做了什么

**`lib/errors/` 三件套**：`normalize`（各汇聚点 → `AppError`，全是纯函数）、`message`（码 → 本地化文案）、`present`（唯一渲染决策）。

**文案归前端**（Core ADR-0018）。理由不是偏好：这个产品里语言是**客户端运行时开关**（`setPreferredLanguage` 只调 `changeLanguage`，不刷新也不重发请求），而 **agent 的错误会进聊天记录并持久化**——服务端本地化的串会留下一份永远改不回来的中英混排会话历史。仓里已为定价卡片打过同一场仗（`plan-copy.dto.ts`）。

服务端那句 `publicMessage`（「这份 PDF 像是扫描件」）保留，但**降为 detail 行**，本地化的码文案永远当标题——屏幕上因此永远不会只剩一句外语。

**BFF 从「整体替换」改成白名单投影**：只放行 `errorCode`/`subCode`/`params`/`requestId`/`retryable` 五个键，`message` 一律不转发。**白名单本身就是安全边界**——上游 4xx 原文可能是写给运营的英文，甚至说出这个部署配了哪些渠道。四处 500 catch 不再回 `errorMessage`（那里面装的是 undici 内部与内网 host，而 `editClient.readError` **第一个读的就是它**），改为进服务端日志。

**删 `friendlyAgentError` 的七条正则，并在同一个提交里把额度闸门改成读码。** 这两件事不能拆：闸门的正确性此前挂在另一个函数产出的四个汉字「额度不足」上，谁把那句国际化成英文它就静默失效，而没有任何测试会红。分两个 PR 做，中间那一刻闸门是坏的。

**补上四档从来没有过的边界**：`global-error.tsx`（根布局崩溃时的纯白屏；这一档刻意不依赖 i18n 与设计系统组件——它们正是可能已经挂掉的东西，所以双语内联）、`/dashboard` 段级边界、`window.onerror` + `unhandledrejection`、axios 拦截器上的归一化。

**三处最痛的静默**：手动保存失败（用户按了按钮然后什么都没发生）、开 AI 前的同步失败（**agent 因此读的是旧简历，会照着过时内容提改动**）、SSE 帧解析失败。

## 兼容性

`normalize` 在没有 `errorCode` 时按 HTTP 状态合成，用的是与后端逐条一致的同一张表。「老后端 + 新前端」降级到今天的粒度、不会更差——有测试钉着这条。

## 验证

- `tsc --noEmit` 干净；`next lint` 零 warning/error；`next build` 通过
- `i18n:check` 通过（顺带修了两个真实的缺键）
- `app.test.ts` 加三组断言，全部通过（并用故意改坏的方式验证过它们确实在执行）：
  - **码 → 文案的覆盖测试**：遍历 13 个码 + `unknown`，断言 zh/en 都有文案且键同构。**这条是「文案归前端」能成立的前提**——后端加了新码而前端没写文案，就在前端仓 CI 红。
  - **归一化**：新后端 / 老后端只有状态码 / 老后端只有字符串码 / 畸形体 / 网络失败 / abort / SSE 帧，逐条断言。含命名回归用例：`429 + quota_exhausted → quota_exceeded 且不是 rate_limited`，以及「BFF 那句 `Backend request failed with status 429` 绝不能当文案渲染」。
  - **文案**：本地化的码文案当标题、服务端那句当 detail；认不出的码退到通用兜底而不是把标识符渲染出来。

视觉验收留给你：起 dev server 后按额度耗尽 / 被限流 / 模型名写错 / provider 挂 / 会话失效 / 校验失败六条复现走一遍，中英各一次；另外有一个专门场景——**toast 还挂在屏幕上时切语言**，那正是这套设计买来的东西。

🤖 Generated with [Claude Code](https://claude.com/claude-code)