### PR TITLE
feat(web): 任务清单变成一张能收起来的卡

### DIFF
--- a/apps/web/scripts/i18n-logs/scan.md
+++ b/apps/web/scripts/i18n-logs/scan.md
@@ -1,3 +1,3 @@
-# i18n Scan Report (8/12/2026, 4:32:53 AM)
+# i18n Scan Report (8/12/2026, 3:13:02 PM)
 
 ✅ All checks passed! No issues found.

--- a/apps/web/src/app.test.ts
+++ b/apps/web/src/app.test.ts
@@ -11,6 +11,16 @@ import { appErrorCopy } from '@/lib/errors/message';
 import { presentAppError } from '@/lib/errors/present';
 import { APP_ERROR_CODES, opensBillingGate } from '@/lib/errors/types';
 import { projectUpstreamError } from '@/app/api/chat-agent/errorProjection';
+import {
+  isPlanFulfilled,
+  isRetirablePlan,
+  segmentsOf,
+} from '@/app/dashboard/edit/_components/ai/conversation/TasksCard';
+import type {
+  ChatMessage,
+  PlanTodo,
+  TodoSegment,
+} from '@/app/dashboard/edit/_components/ai/types';
 import { ZodError } from 'zod';
 import {
   applyChangeToSections,
@@ -1093,6 +1103,46 @@ function testBffErrorProjection() {
   assert.equal(roundTrip.requestId, 'req-9');
 }
 
+/**
+ * 任务清单卡的两条判据 + 片段降级。
+ *
+ * 判据是从 ChatThread 搬到 TasksCard 的——搬动最容易在语义上出错的地方，正是这种
+ * 「看起来只是换个文件」的改动，所以把行为钉死在这里。
+ */
+function testTasksCard() {
+  const plan = (todos: PlanTodo[], extra: Partial<ChatMessage> = {}): ChatMessage =>
+    ({ id: 'p', role: 'plan', content: '', todos, ...extra }) as ChatMessage;
+
+  // 一条未完成就不算跑完；空清单也不算——否则卡片刚建好、一条 todo 都还没到时
+  // 就会被判成"完成"，然后立刻退场。
+  assert.equal(isPlanFulfilled(plan([])), false);
+  assert.equal(
+    isPlanFulfilled(plan([{ content: 'a', status: 'completed' }, { content: 'b', status: 'pending' }])),
+    false,
+  );
+  assert.equal(isPlanFulfilled(plan([{ content: 'a', status: 'completed' }])), true);
+
+  // 子代理清单没有右侧产物，不能退场——退了就"起过一个子代理"这件事无迹可寻。
+  const doneTodos: PlanTodo[] = [{ content: 'a', status: 'completed' }];
+  assert.equal(isRetirablePlan(plan(doneTodos)), true);
+  assert.equal(isRetirablePlan(plan(doneTodos, { subagentName: 'translator' })), false);
+  assert.equal(isRetirablePlan(plan([{ content: 'a', status: 'pending' }])), false);
+
+  // 片段降级：后端没发 segments（老后端、或模型没写标记）时，整条 content 当一段纯文本。
+  assert.deepEqual(segmentsOf({ content: '把摘要改短', status: 'pending' }), [
+    { type: 'text', text: '把摘要改短' },
+  ]);
+  assert.deepEqual(segmentsOf({ content: 'x', status: 'pending', segments: [] }), [
+    { type: 'text', text: 'x' },
+  ]);
+  // 有 segments 就用它，content 只是给不认 segments 的消费者看的。
+  const segs: TodoSegment[] = [
+    { type: 'chip', verb: '读取', rest: '简历', kind: 'read' },
+    { type: 'text', text: '再决定' },
+  ];
+  assert.deepEqual(segmentsOf({ content: '读取 简历 再决定', status: 'pending', segments: segs }), segs);
+}
+
 async function main() {
   await testAiSessionStore();
   testImportResumeValidation();
@@ -1112,6 +1162,7 @@ async function main() {
   testErrorNormalize();
   testErrorCopy();
   testBffErrorProjection();
+  testTasksCard();
 }
 
 main().catch((error) => {

--- a/apps/web/src/app/dashboard/edit/_components/ai/AiChatShell.tsx
+++ b/apps/web/src/app/dashboard/edit/_components/ai/AiChatShell.tsx
@@ -687,6 +687,9 @@ export default function AiChatShell({
                   ...(sub ? { subagentName: sub } : { skillId: canvasSkill }),
                   content: sub ? '' : payload?.label || '任务清单',
                   todos,
+                  // 卡片自己走秒。以第一条 plan_update 为起点而不是 run_started：
+                  // 用户看到的这张卡就是从这一刻开始的。
+                  startedAt: Date.now(),
                   status: allDone ? 'done' : 'running',
                 });
               }

--- a/apps/web/src/app/dashboard/edit/_components/ai/conversation/ChatThread.tsx
+++ b/apps/web/src/app/dashboard/edit/_components/ai/conversation/ChatThread.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
 import {
@@ -21,6 +21,11 @@ import { PolarisGlyph } from '../PolarisMark';
 import { WidgetHost } from '@magic-resume/genui';
 import { WIDGETS } from '../widgets/registry';
 import type { ApprovalRequest, ChatMessage, SkillId } from '../types';
+import TasksCard, {
+  PLAN_DWELL_MS,
+  isPlanFulfilled,
+  isRetirablePlan,
+} from './TasksCard';
 import type { WidgetActionResult } from '@magic-resume/genui/contract';
 import ActivityOrb from './ActivityOrb';
 import { activityLabelKey, type AgentActivity } from './agentActivity';
@@ -162,299 +167,6 @@ function ExecCard({
   );
 }
 
-/**
- * A live review checklist (the analyze todolist). The agent ticks each step —
- * 读取简历 → 每个角色评审 → 汇总评分 — as its backend progress events land, so the
- * card is the narration of "分别 review" instead of one opaque "完成" badge. Once
- * done it doubles as the score-canvas toggle (the old exec-card affordance).
- */
-/**
- * 判据：这次运行是**真正跑完**，还是被中止 / 失败了。
- *
- * 两者都会被 `consumeStream` 的收尾置成 `status: 'done'`，光看它区分不了。差异在
- * 步骤上——正常收尾会把全部步骤置为 completed，而中止时只是把 in_progress 退回
- * pending。所以"全部 completed"才是跑完；有 pending 残留的那张卡必须留在对话里，
- * 否则一次被打断的运行会无声消失，用户连"它做到哪一步停的"都看不到。
- */
-/** 跑完之后停留多久再退场——让用户看见它确实完成了。 */
-const PLAN_DWELL_MS = 700;
-
-/**
- * 时间线几何。
- *
- * 这几个数**必须互相咬合**——导轨的 x 要等于标记盒中心、断口要等于图元自身高度、
- * orb 的落点要等于行高——所以集中成常量、由代码算出彼此，而不是散成一堆 Tailwind
- * arbitrary class 各写各的。上一版把 `left-[9.5px]` 和 `9.5 = 20/2 - 1/2` 的来历
- * 分开写在两处，读代码的人看不出它们是同一个数。
- */
-const TL = {
-  /** 一行文字的行高，也是标记盒的高度 */
-  rowH: 18,
-  /** 标记列宽。导轨画在它的中轴上 */
-  colW: 20,
-  /** 行与行之间的留白 */
-  gapY: 10,
-  /** 未开始 / 进行中的圆点直径 */
-  dot: 8,
-  /** 完成的 ✓ 尺寸 */
-  check: 12,
-  /** orb 换步时滑过去的时长 */
-  strideMs: 380,
-} as const;
-/** 导轨中轴。1px 的线要压在中心上，所以再减半个线宽。 */
-const TL_AXIS = TL.colW / 2 - 0.5;
-/** 图元在行内的上下边界——导轨在这里让开，不糊在标记上。 */
-const gapFor = (glyph: number) => ({
-  top: (TL.rowH - glyph) / 2,
-  bottom: (TL.rowH + glyph) / 2,
-});
-
-export function isPlanFulfilled(message: ChatMessage): boolean {
-  const todos = message.todos ?? [];
-  return todos.length > 0 && todos.every((t) => t.status === 'completed');
-}
-
-/** 技能清单（有 skillId、结果落在右侧画布）才退场；子代理清单没有产物，不能退场。 */
-export function isRetirablePlan(message: ChatMessage): boolean {
-  return message.role === 'plan' && !message.subagentName && isPlanFulfilled(message);
-}
-
-function PlanCard({
-  message,
-  retired,
-  onToggleCanvas,
-  isCanvasOpen,
-  activity,
-}: {
-  message: ChatMessage;
-  /** 已过完停留期：技能清单收成一行可点的指针，不再是卡。 */
-  retired?: boolean;
-  onToggleCanvas: (id: SkillId) => void;
-  isCanvasOpen: boolean;
-  /** agent 此刻在做哪一类活儿——决定骑在导轨上那颗 orb 的形态。 */
-  activity?: AgentActivity | null;
-}) {
-  const { t } = useTranslation();
-  const todos = message.todos ?? [];
-  const total = todos.length;
-  const done = todos.filter((t) => t.status === 'completed').length;
-  const fulfilled = isPlanFulfilled(message);
-  const finished = message.status === 'done' || fulfilled;
-  const reduce = useReducedMotion() ?? false;
-
-  // orb 落在哪一行——量出来的，不是算出来的：标签可能折行，行高就不再等距，
-  // 用 index × 行高推位置迟早会错位。
-  const itemRefs = useRef<(HTMLLIElement | null)[]>([]);
-  const [orbTop, setOrbTop] = useState<number | null>(null);
-
-  // 当前这一步 = 第一个未完成的。后端会同时把多步标成 in_progress，只认第一个，
-  // 否则三处一起发光就读成「三件事在并行」，而实际上只是状态没细分。
-  // （放在早退分支之前，因为下面那个 hook 依赖它——hooks 不能在 return 之后。）
-  const activeIndex = todos.findIndex((x) => x.status !== 'completed');
-  /** 已走完的行数。-1 表示一条未完成的都没有，即全部完成。 */
-  const doneUpTo = activeIndex === -1 ? total : activeIndex;
-
-  // useLayoutEffect：位置必须在绘制前写进 transform，否则 orb 会先在第一行闪一帧
-  // 再跳到当前行。
-  useLayoutEffect(() => {
-    if (finished || activeIndex < 0) {
-      setOrbTop(null);
-      return;
-    }
-    const el = itemRefs.current[activeIndex];
-    setOrbTop(el ? el.offsetTop : null);
-  }, [activeIndex, finished, total]);
-
-  // 技能清单跑完并过了停留期 → 收成一行可点的指针。
-  //
-  // 它必须留下点什么：右侧那份报告没有别的入口了——实时画布会把它顶掉，而“再加一
-  // 颗头部按钮”被否掉。时间线上留一条指针既不是卡也不是新控件，位置还正好在这次
-  // 运行发生的地方。
-  if (retired) {
-    return (
-      <button
-        type="button"
-        onClick={() => onToggleCanvas(message.skillId ?? 'analyze')}
-        className="group flex items-center gap-2 text-[11px] text-neutral-500 transition-colors hover:text-neutral-300 cursor-pointer"
-      >
-        <Check size={11} className="shrink-0 text-neutral-600" />
-        <span className="truncate">{message.content || t('aiLab.chat.taskList')}</span>
-        <span className="shrink-0 text-sky-400/70 transition-colors group-hover:text-sky-300">
-          {isCanvasOpen ? t('aiLab.chat.collapse') : t('aiLab.chat.view')}
-        </span>
-      </button>
-    );
-  }
-
-  // 子代理跑完 → 降成一行日志。它没有右侧产物，整张卡留着只是噪音；但完全抹掉
-  // 又会让"起过一个子代理"这件事无迹可寻，所以留一行。
-  if (message.subagentName && finished) {
-    const name =
-      message.subagentName !== '子代理' && message.subagentName !== 'general-purpose'
-        ? ` · ${message.subagentName}`
-        : '';
-    return (
-      <div className="flex items-center gap-2 text-[11px] text-neutral-500">
-        <Check size={11} className="shrink-0 text-neutral-600" />
-        <span className="truncate">
-          {t('aiLab.chat.subagent')}
-          {name}
-        </span>
-      </div>
-    );
-  }
-
-  return (
-    // AI-native 的 ambient activity（skill: ai-native-ui-design）：不用进度条、不用
-    // 「Agent working…」标签，让**正在被处理的那一步自己发光**。上一版把卡片扒光后
-    // 五行长得一模一样、只差颜色深浅，等于把"AI 此刻在哪儿"这条最重要的信息扔了。
-    <div className="flex items-start">
-      <div className="min-w-[240px] max-w-sm">
-        {/* 计数右对齐：它是行尾的说明，不是标题旁的徽章。进度已经由导轨承载，
-            这里只补一个"总共多少步"——长清单里那是唯一说得出总量的地方。 */}
-        <div className="flex items-center justify-between gap-3 text-[12px]">
-          <span className="min-w-0 truncate font-medium text-neutral-300">
-            {message.subagentName ? (
-              <>
-                <span className="text-sky-400">{t('aiLab.chat.subagent')}</span>
-                {message.subagentName !== '子代理' && message.subagentName !== 'general-purpose'
-                  ? ` · ${message.subagentName}`
-                  : ''}
-              </>
-            ) : (
-              message.content || t('aiLab.chat.taskList')
-            )}
-          </span>
-          {finished ? (
-            <Check size={12} className="shrink-0 text-emerald-400" />
-          ) : total > 0 ? (
-            <span className="shrink-0 text-[11px] tabular-nums text-neutral-600">
-              {done}/{total}
-            </span>
-          ) : (
-            <BreathGlyph size={11} className="text-sky-400/70" />
-          )}
-        </div>
-
-        {/* 导轨由每一行**自己**画出与相邻标记之间的那一小段，而不再是 <ul> 的背景渐变。
-            旧写法里导轨画在容器最左侧、标记被 pl-3.5 推到 14px 之外，两套坐标系，
-            那条线从设计上就不可能穿过任何一个点——量出来差 16px。现在线段的 x 直接
-            由标记盒宽度算出（TL_AXIS），穿过是**构造**出来的，不是调出来的。
-            断口取各自图元的实际高度（✓ 12px / 圆点 8px），线在标记处让开。 */}
-        <ul className="relative mt-2.5">
-          {/* 骑在导轨上的那颗 orb —— 这张卡最想说的一句话。
-              它不是"第三种标记"，而是 **agent 本人站在计划的哪一级台阶上**：形态随
-              activity 变（读简历 / 评估 / 干活各不相同），位置随进度往下滑。这样一颗
-              球同时回答了「在做什么」和「做到哪儿」，而计数和导轨都只回答后者。
-              落点是量出来的（li.offsetTop），标签折行也不会错位；位移只动 transform，
-              交给合成器，流式那几帧再忙也不掉帧。 */}
-          {orbTop !== null && (
-            <span
-              aria-hidden
-              className="pointer-events-none absolute z-10 grid place-items-center"
-              style={{
-                left: 0,
-                top: 0,
-                width: TL.colW,
-                height: TL.rowH,
-                transform: `translateY(${orbTop}px)`,
-                transition: reduce ? undefined : `transform ${TL.strideMs}ms cubic-bezier(0.22,1,0.36,1)`,
-              }}
-            >
-              <ActivityOrb activity={activity ?? 'working'} />
-            </span>
-          )}
-          {todos.map((todo, i) => {
-            const isActive = !finished && i === activeIndex;
-            const isDone = todo.status === 'completed';
-            const ridden = isActive && orbTop !== null;
-            const gap = gapFor(isDone ? TL.check : TL.dot);
-            // 一个接头由「上一行的下半段 + 本行的上半段」拼成，两者必须同色，
-            // 所以都用「上一行是否已完成」来判定。
-            const linkAboveDone = i - 1 < doneUpTo;
-            const linkBelowDone = i < doneUpTo;
-            return (
-              <li
-                key={`${todo.content}-${i}`}
-                ref={(el) => {
-                  itemRefs.current[i] = el;
-                }}
-                aria-current={isActive ? 'step' : undefined}
-                className="relative flex gap-2"
-                style={{ paddingBottom: i === total - 1 ? 0 : TL.gapY }}
-              >
-                {i > 0 && (
-                  <span
-                    aria-hidden
-                    className={cn(
-                      'absolute top-0 transition-colors duration-150',
-                      linkAboveDone ? 'bg-sky-400/45' : 'bg-neutral-800'
-                    )}
-                    style={{ left: TL_AXIS, width: 1, height: gap.top }}
-                  />
-                )}
-                {i < total - 1 && (
-                  <span
-                    aria-hidden
-                    className={cn(
-                      'absolute bottom-0 transition-colors duration-150',
-                      linkBelowDone ? 'bg-sky-400/45' : 'bg-neutral-800'
-                    )}
-                    style={{ left: TL_AXIS, width: 1, top: gap.bottom }}
-                  />
-                )}
-                {/* 固定 20×18 的标记盒：三种状态占位完全相同，标签左缘才能齐平。
-                    旧写法把 12px 的 ✓ 和 6px 的圆点直接并排塞进 flex，宽度不等，
-                    量出来首行标签比其余行右移 12px。 */}
-                <span
-                  className="relative grid shrink-0 place-items-center"
-                  style={{ width: TL.colW, height: TL.rowH }}
-                >
-                  {isDone ? (
-                    // 打勾是这张卡上唯一"有事发生"的瞬间，给它一个极短的落定：
-                    // 只动 scale/opacity，不弹跳。
-                    <motion.span
-                      initial={reduce ? false : { opacity: 0, scale: 0.5 }}
-                      animate={{ opacity: 1, scale: 1 }}
-                      transition={{ duration: 0.22, ease: [0.22, 1, 0.36, 1] }}
-                      className="flex"
-                    >
-                      <Check size={TL.check} className="text-neutral-500" />
-                    </motion.span>
-                  ) : (
-                    // 当前行的点被 orb 盖住了，就别再画一颗——两颗同心圆只会糊在一起。
-                    !ridden && (
-                      <span
-                        className={cn(
-                          'rounded-full transition-colors duration-150',
-                          isActive ? 'step-dot-active bg-sky-400' : 'border border-neutral-700'
-                        )}
-                        style={{ width: TL.dot, height: TL.dot }}
-                      />
-                    )
-                  )}
-                </span>
-                <span
-                  className={cn(
-                    'min-w-0 text-[12px] transition-colors duration-150',
-                    isDone
-                      ? 'text-neutral-500'
-                      : isActive
-                        ? 'step-text-active text-sky-100'
-                        : 'text-neutral-600'
-                  )}
-                  style={{ lineHeight: `${TL.rowH}px` }}
-                >
-                  {todo.content}
-                </span>
-              </li>
-            );
-          })}
-        </ul>
-      </div>
-    </div>
-  );
-}
 
 /**
  * Human-in-the-loop approval prompt. The assistant asks before a sensitive action;
@@ -767,6 +479,8 @@ type ChatThreadProps = {
   activity?: AgentActivity | null;
 };
 
+export { isPlanFulfilled, isRetirablePlan };
+
 export default function ChatThread({ messages, onToggleCanvas, openCanvasSkillId, onLogClick, onApproval, onWidgetAction, thinking, activity }: ChatThreadProps) {
   const endRef = useRef<HTMLDivElement>(null);
   const reduceMotion = useReducedMotion() ?? false;
@@ -852,7 +566,7 @@ export default function ChatThread({ messages, onToggleCanvas, openCanvasSkillId
             ) : m.role === 'approval' ? (
               <ApprovalCard message={m} onApproval={onApproval} />
             ) : m.role === 'plan' ? (
-              <PlanCard
+              <TasksCard
                 message={m}
                 retired={retired.has(m.id)}
                 onToggleCanvas={onToggleCanvas}

--- a/apps/web/src/app/dashboard/edit/_components/ai/conversation/TasksCard.tsx
+++ b/apps/web/src/app/dashboard/edit/_components/ai/conversation/TasksCard.tsx
@@ -1,0 +1,285 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+import { Check, ChevronDown } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { cn } from '@/lib/utils';
+import type { ChatMessage, PlanTodo, SkillId, TodoSegment } from '../types';
+import ActivityOrb from './ActivityOrb';
+import type { AgentActivity } from './agentActivity';
+import { useSpringHeight } from './useSpringHeight';
+
+/**
+ * 任务清单卡。
+ *
+ * 取代此前那条「时间线导轨 + 骑在上面的 orb」：那一版把步骤裸露成一列，读得出进度，
+ * 但一次运行在对话里没有边界——三张清单连着出现时分不清哪几步属于哪一次。现在它是
+ * 一张**有容器的卡**，跑完能收起，于是「这一轮做了什么」成了一个可以整体折叠的东西。
+ *
+ * 每一行左侧的形态由 agent 自己声明（`todo.activity`，后端从 `[[kind:label]]` 标记
+ * 派生），不是我们猜的——这正是 `agentActivity.ts` 里那条「不演一个并没有发生的状态」
+ * 得以放宽的原因：现在有真实来源了。
+ */
+
+/** 跑完之后停留多久再退场——让用户看见它确实完成了。 */
+export const PLAN_DWELL_MS = 700;
+
+export function isPlanFulfilled(message: ChatMessage): boolean {
+  const todos = message.todos ?? [];
+  return todos.length > 0 && todos.every((t) => t.status === 'completed');
+}
+
+/** 技能清单（有 skillId、结果落在右侧画布）才退场；子代理清单没有产物，不能退场。 */
+export function isRetirablePlan(message: ChatMessage): boolean {
+  return message.role === 'plan' && !message.subagentName && isPlanFulfilled(message);
+}
+
+export default function TasksCard({
+  message,
+  retired,
+  onToggleCanvas,
+  isCanvasOpen,
+  activity,
+}: {
+  message: ChatMessage;
+  /** 已过完停留期：技能清单收成一行可点的指针，不再是卡。 */
+  retired?: boolean;
+  onToggleCanvas: (id: SkillId) => void;
+  isCanvasOpen: boolean;
+  /** agent 此刻在做哪一类活儿。只在 todo 自己没声明时兜底。 */
+  activity?: AgentActivity | null;
+}) {
+  const { t } = useTranslation();
+  const todos = message.todos ?? [];
+  const total = todos.length;
+  const done = todos.filter((x) => x.status === 'completed').length;
+  const fulfilled = isPlanFulfilled(message);
+  const finished = message.status === 'done' || fulfilled;
+
+  const [collapsed, setCollapsed] = useState(false);
+  const { clipRef, contentRef, settle } = useSpringHeight<HTMLUListElement>(collapsed);
+
+  // 行数、状态、语言任何一样变了都要重新量——不重新量就会裁掉最后一行。
+  useEffect(() => {
+    settle();
+  }, [settle, total, done, finished]);
+
+  const elapsed = useElapsedSeconds(message.startedAt, finished);
+
+  // 技能清单跑完并过了停留期 → 收成一行可点的指针。
+  //
+  // 它必须留下点什么：右侧那份报告没有别的入口了——实时画布会把它顶掉。时间线上留一条
+  // 指针既不是卡也不是新控件，位置还正好在这次运行发生的地方。
+  if (retired) {
+    return (
+      <button
+        type="button"
+        onClick={() => onToggleCanvas(message.skillId ?? 'analyze')}
+        className="group flex cursor-pointer items-center gap-2 text-[11px] text-neutral-500 transition-colors hover:text-neutral-300"
+      >
+        <Check size={11} className="shrink-0 text-neutral-600" />
+        <span className="truncate">{message.content || t('aiLab.chat.taskList')}</span>
+        <span className="shrink-0 text-sky-400/70 transition-colors group-hover:text-sky-300">
+          {isCanvasOpen ? t('aiLab.chat.collapse') : t('aiLab.chat.view')}
+        </span>
+      </button>
+    );
+  }
+
+  // 子代理跑完 → 降成一行日志。它没有右侧产物，整张卡留着只是噪音；但完全抹掉又会让
+  // 「起过一个子代理」这件事无迹可寻，所以留一行。
+  if (message.subagentName && finished) {
+    const name = namedSubagent(message.subagentName);
+    return (
+      <div className="flex items-center gap-2 text-[11px] text-neutral-500">
+        <Check size={11} className="shrink-0 text-neutral-600" />
+        <span className="truncate">
+          {t('aiLab.chat.subagent')}
+          {name ? ` · ${name}` : ''}
+        </span>
+      </div>
+    );
+  }
+
+  const title = message.subagentName
+    ? `${t('aiLab.chat.subagent')}${namedSubagent(message.subagentName) ? ` · ${namedSubagent(message.subagentName)}` : ''}`
+    : message.content || t('aiLab.chat.tasks');
+
+  return (
+    <div className="w-full max-w-lg">
+      <div
+        className={cn(
+          'relative overflow-hidden rounded-2xl bg-[#16171b] px-4 py-3',
+          'motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-2 motion-safe:duration-300'
+        )}
+      >
+        {/* 极光：两团径向渐变缓慢漂移，跑完整体提亮。它是这张卡唯一的「还活着」信号——
+            比进度条诚实：它不假装知道还剩多少。 */}
+        <span
+          aria-hidden
+          className={cn(
+            'pointer-events-none absolute inset-0 transition-opacity duration-700 motion-safe:animate-[aurora_14s_ease-in-out_infinite_alternate]',
+            finished ? 'opacity-100' : 'opacity-60'
+          )}
+          style={{
+            background: finished
+              ? 'radial-gradient(120% 180% at 86% 44%, rgba(56,189,248,.34) 0%, transparent 62%), radial-gradient(90% 140% at 60% 86%, rgba(14,116,165,.26) 0%, transparent 58%)'
+              : 'radial-gradient(120% 180% at 88% 42%, rgba(56,189,248,.20) 0%, transparent 62%), radial-gradient(90% 140% at 62% 88%, rgba(14,116,165,.18) 0%, transparent 58%)',
+          }}
+        />
+
+        <div className="relative">
+          <button
+            type="button"
+            onClick={() => setCollapsed((v) => !v)}
+            aria-expanded={!collapsed}
+            className="flex w-full cursor-pointer items-center gap-2.5 text-left"
+          >
+            <ChevronDown
+              size={14}
+              className={cn(
+                'shrink-0 text-neutral-300 transition-transform duration-300',
+                collapsed && '-rotate-90'
+              )}
+            />
+            <span className="min-w-0 truncate text-[13px] font-medium text-neutral-200">
+              {title}
+            </span>
+            <span className="flex-1" />
+            {elapsed !== null && (
+              <span className="shrink-0 rounded-full bg-white/10 px-2.5 py-0.5 text-[11.5px] tabular-nums text-neutral-300">
+                {t('aiLab.chat.elapsed', { seconds: elapsed })}
+              </span>
+            )}
+            {finished ? (
+              <span className="shrink-0 rounded-full bg-sky-950/80 px-3 py-0.5 text-[11.5px] font-medium text-sky-300">
+                {t('aiLab.chat.completed')}
+              </span>
+            ) : (
+              <span className="shrink-0 text-[12px] tabular-nums text-neutral-400">
+                {done}/{Math.max(total, 1)}
+              </span>
+            )}
+          </button>
+
+          {/* 高度由 useSpringHeight 逐帧写入——**这里刻意没有 CSS transition**。
+              行是成串到达的，transition 每次从零速度重启，看起来一顿一顿。 */}
+          <div ref={clipRef} className="overflow-hidden" style={{ willChange: 'height' }}>
+            {/* 只能用 padding 不能用 margin：测量不含 margin，留 margin 就会被裁掉。 */}
+            <ul ref={contentRef} className="flex list-none flex-col gap-2 pb-0.5 pt-2">
+              {todos.map((todo, i) => (
+                <TaskRow
+                  key={`${todo.content}-${i}`}
+                  todo={todo}
+                  fallbackActivity={activity}
+                />
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TaskRow({
+  todo,
+  fallbackActivity,
+}: {
+  todo: PlanTodo;
+  fallbackActivity?: AgentActivity | null;
+}) {
+  const isDone = todo.status === 'completed';
+  // agent 声明的优先；它没说才用「这一轮整体在干什么」兜底。
+  const rowActivity = todo.activity ?? fallbackActivity ?? 'working';
+  const segments = segmentsOf(todo);
+
+  return (
+    <li className={cn('flex items-start gap-2.5 transition-opacity duration-500', isDone && 'opacity-45')}>
+      <span className="grid h-5 w-5 shrink-0 place-items-center">
+        {isDone ? (
+          <span className="grid h-[18px] w-[18px] place-items-center rounded-full bg-sky-500 motion-safe:animate-in motion-safe:zoom-in-75 motion-safe:duration-300">
+            <Check size={11} className="text-white" strokeWidth={3} />
+          </span>
+        ) : (
+          <ActivityOrb activity={rowActivity} />
+        )}
+      </span>
+      <span className="flex min-w-0 flex-wrap items-center gap-1.5 pt-px text-[13px] text-neutral-200">
+        {segments.map((seg, i) =>
+          seg.type === 'chip' ? (
+            <span
+              key={i}
+              className={cn(
+                'inline-flex max-w-[16rem] items-center gap-1.5 rounded-full border py-0.5 pl-2 pr-2.5 transition-colors duration-500',
+                isDone
+                  ? 'border-transparent bg-white/[0.07]'
+                  : 'border-sky-400/40 bg-sky-400/10'
+              )}
+            >
+              <span
+                className={cn(
+                  'truncate text-[12.5px]',
+                  isDone ? 'text-neutral-400 line-through' : 'text-sky-100'
+                )}
+              >
+                <span className={cn(!isDone && 'text-white')}>{seg.verb}</span>
+                {seg.rest ? ` ${seg.rest}` : ''}
+              </span>
+            </span>
+          ) : (
+            <span key={i} className={cn('text-neutral-400', isDone && 'line-through')}>
+              {seg.text}
+            </span>
+          )
+        )}
+      </span>
+    </li>
+  );
+}
+
+/**
+ * 这一行要渲染哪些片段。
+ *
+ * 后端没发 `segments` 就退回整条 `content` 当一段纯文本——**这是默认路径**：模型不写
+ * 标记不算错，老后端也还没发这个字段。抽成纯函数是因为这是唯一一处会静默退化的地方，
+ * 内联在 JSX 里没有断言钉得住它。
+ */
+export function segmentsOf(todo: PlanTodo): TodoSegment[] {
+  return todo.segments?.length
+    ? todo.segments
+    : [{ type: 'text', text: todo.content }];
+}
+
+/** `子代理` / `general-purpose` 是占位名，不值得占标题里的位置。 */
+function namedSubagent(name: string): string {
+  return name === '子代理' || name === 'general-purpose' ? '' : name;
+}
+
+/**
+ * 这一轮跑了多少秒。
+ *
+ * 刻意**不显示 token 数**：`llm_usage` 事件其实一直在流，但原始 token 对求职者没有
+ * 意义，还会把「用一次要花多少」变成每轮都在盯的数字。耗时是他真正在等的东西。
+ */
+function useElapsedSeconds(startedAt: number | undefined, finished: boolean): number | null {
+  const [seconds, setSeconds] = useState<number | null>(
+    startedAt ? Math.floor((Date.now() - startedAt) / 1000) : null
+  );
+  const frozen = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!startedAt) return;
+    if (finished) {
+      // 跑完就定格。继续走秒会让一张已经结束的卡看起来还在工作。
+      if (frozen.current === null) frozen.current = Math.floor((Date.now() - startedAt) / 1000);
+      setSeconds(frozen.current);
+      return;
+    }
+    setSeconds(Math.floor((Date.now() - startedAt) / 1000));
+    const id = setInterval(() => setSeconds(Math.floor((Date.now() - startedAt) / 1000)), 1000);
+    return () => clearInterval(id);
+  }, [startedAt, finished]);
+
+  return startedAt ? seconds : null;
+}

--- a/apps/web/src/app/dashboard/edit/_components/ai/conversation/useSpringHeight.ts
+++ b/apps/web/src/app/dashboard/edit/_components/ai/conversation/useSpringHeight.ts
@@ -1,0 +1,135 @@
+'use client';
+
+import { useCallback, useEffect, useRef } from 'react';
+import { useReducedMotion } from 'framer-motion';
+
+/**
+ * 让一个可折叠区域的高度按**物理**变化，而不是按一条贝塞尔曲线走完。
+ *
+ * 参照的是真实产品的逐帧数据：一次长高 165→182px，增量 6,3,2,2,2,2 —— 起步快、单调
+ * 衰减、**从不冲过头**。那是临界阻尼弹簧，不是会回弹的弹簧振子。
+ *
+ * 换掉 CSS transition 的真正理由不是曲线，是**速度可以被继承**：任务行是成串到达的
+ * （一次运行里四五次追加很常见），CSS transition 每次都从零速度重启，看起来一顿一顿；
+ * 弹簧带着上一次的余速接着走。
+ */
+
+/** 临界阻尼：damping ≈ 2√(k·m)。取略微过阻尼，宁可稳一点也不要回弹。 */
+const STIFFNESS = 210;
+const DAMPING = 30;
+/** 固定子步长积分——大步长会让高刚度弹簧发散。 */
+const SUB_STEP = 1 / 240;
+/** 停机阈值：位移与速度都进了这个范围就吸附到目标，免得永远在跑 rAF。 */
+const EPSILON = 0.15;
+
+export interface SpringHeight<C extends HTMLElement = HTMLElement> {
+  /** 挂到被裁剪的外层（`overflow: hidden`）。 */
+  clipRef: React.RefObject<HTMLDivElement | null>;
+  /** 挂到内容本身。**测量口径只此一处**——见下面的注释。 */
+  contentRef: React.RefObject<C | null>;
+  /** 内容变了或折叠态变了，调它。 */
+  settle: () => void;
+}
+
+export function useSpringHeight<C extends HTMLElement = HTMLElement>(
+  collapsed: boolean,
+): SpringHeight<C> {
+  const clipRef = useRef<HTMLDivElement | null>(null);
+  const contentRef = useRef<C | null>(null);
+  const reduce = useReducedMotion() ?? false;
+
+  const state = useRef({ x: 0, v: 0, target: 0, raf: 0, last: 0, primed: false });
+
+  /**
+   * 内容该占多高。
+   *
+   * 两条都是踩出来的，不是风格选择：
+   * 1. 用 `getBoundingClientRect().height` 而不是 `offsetHeight`——后者**四舍五入成
+   *    整数**，13.5px 字号配 9px 间距必然算出小数，抹掉的那不到 1px 正好是最后一行
+   *    的字母下伸部。再 `ceil` 一次，彻底不留裁掉的余地。
+   * 2. 内容容器**只能用 padding 不能用 margin**：两种测量都不含 margin，留 margin 就
+   *    等于让裁剪框比内容矮那么多，底下一截被 `overflow: hidden` 切掉。
+   */
+  const measure = useCallback(() => {
+    const el = contentRef.current;
+    if (!el) return 0;
+    return Math.ceil(el.getBoundingClientRect().height);
+  }, []);
+
+  const write = useCallback((h: number) => {
+    const clip = clipRef.current;
+    if (clip) clip.style.height = `${Math.max(0, h)}px`;
+  }, []);
+
+  const settle = useCallback(() => {
+    const s = state.current;
+    s.target = collapsed ? 0 : measure();
+
+    // 首帧直接吸附：卡片刚出现时不该从 0 弹开一次——那是它「本来就有的高度」，
+    // 不是一次变化。
+    if (!s.primed) {
+      s.primed = true;
+      s.x = s.target;
+      s.v = 0;
+      write(s.x);
+      return;
+    }
+
+    if (reduce) {
+      s.x = s.target;
+      s.v = 0;
+      write(s.x);
+      return;
+    }
+
+    if (s.raf) return;
+    s.last = performance.now();
+    const step = (now: number) => {
+      const dt = Math.min((now - s.last) / 1000, 1 / 30); // 丢帧时不让它炸
+      s.last = now;
+      let remaining = dt;
+      while (remaining > 0) {
+        const h = Math.min(SUB_STEP, remaining);
+        remaining -= h;
+        const a = -STIFFNESS * (s.x - s.target) - DAMPING * s.v;
+        s.v += a * h;
+        s.x += s.v * h;
+      }
+      write(s.x);
+      if (Math.abs(s.x - s.target) < EPSILON && Math.abs(s.v) < EPSILON) {
+        s.x = s.target;
+        s.v = 0;
+        write(s.x);
+        s.raf = 0;
+        return;
+      }
+      s.raf = requestAnimationFrame(step);
+    };
+    s.raf = requestAnimationFrame(step);
+  }, [collapsed, measure, reduce, write]);
+
+  // 折叠态一变就重新定目标。内容变化由调用方在改完之后调 settle()。
+  useEffect(() => {
+    settle();
+  }, [settle]);
+
+  // 字体加载完、窗口变宽变窄，都会让内容重新排版——**不重新量就会裁掉**。
+  // ResizeObserver 直接盯内容盒，比监听 resize 更准（侧栏开合不触发 window resize）。
+  useEffect(() => {
+    const el = contentRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver(() => settle());
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [settle]);
+
+  useEffect(() => {
+    const s = state.current;
+    return () => {
+      if (s.raf) cancelAnimationFrame(s.raf);
+      s.raf = 0;
+    };
+  }, []);
+
+  return { clipRef, contentRef, settle };
+}

--- a/apps/web/src/app/dashboard/edit/_components/ai/types.ts
+++ b/apps/web/src/app/dashboard/edit/_components/ai/types.ts
@@ -1,5 +1,6 @@
 import type { LucideIcon } from 'lucide-react';
 import type { WidgetInstance } from '@magic-resume/genui/contract';
+import type { AgentActivity } from './conversation/agentActivity';
 
 export type SkillId = 'create' | 'optimize' | 'analyze' | 'fit' | 'translate' | 'interview';
 
@@ -34,10 +35,37 @@ export interface AiSkill {
 
 export type ChatRole = 'user' | 'assistant' | 'exec' | 'log' | 'approval' | 'activity' | 'plan' | 'widget';
 
+/**
+ * 一条 todo 的可渲染片段。
+ *
+ * 后端从 `[[kind:label]]` 标记里解析出来（`todo-segments.ts`）——`write_todos` 是
+ * deepagents 的内置工具、schema 换不掉，标记是模型唯一能往外带结构的通道。
+ * 没有标记就是单独一段 text，这是默认路径而非异常路径。
+ */
+export type TodoSegment =
+  | { type: 'text'; text: string }
+  | {
+      type: 'chip';
+      /** 芯片里加重的那个动词。 */
+      verb: string;
+      /** 动词之后的部分，可为空。 */
+      rest: string;
+      kind: 'read' | 'write' | 'analyze' | 'search' | 'ask' | 'tool';
+    };
+
 /** A single checklist item in a `plan` message — the live analyze todolist. */
 export interface PlanTodo {
   content: string;
   status: 'pending' | 'in_progress' | 'completed';
+  /** 芯片与纯文本混排。缺席时按 `content` 渲染成一段纯文本。 */
+  segments?: TodoSegment[];
+  /**
+   * 这一步在干哪一类活儿，决定左侧 orb 的形态。
+   *
+   * **由 agent 自己声明**（后端从标记的 kind 派生），不是我们猜的——`agentActivity.ts`
+   * 里那条「不演一个并没有发生的状态」因此仍然成立：现在有真实来源了。
+   */
+  activity?: AgentActivity;
 }
 
 /**
@@ -91,6 +119,8 @@ export interface ChatMessage {
   todos?: PlanTodo[];
   /** present when role === 'plan' and the todolist belongs to a subagent (the `task` tool) */
   subagentName?: string;
+  /** present when role === 'plan' — 本轮开始的时刻，卡片据此走秒。 */
+  startedAt?: number;
   /** present when role === 'widget' — a GenUI interactive card (form / decision) */
   widget?: WidgetInstance;
   /**

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1968,3 +1968,11 @@ button {
     transform: translateY(2px);
   }
 }
+
+/* 任务卡的极光。两团径向渐变缓慢漂移——只动 transform，交给合成器，
+   流式那几帧再忙也不掉帧。见 conversation/TasksCard.tsx。 */
+@keyframes aurora {
+  0% { transform: translate3d(0, 0, 0) scale(1); }
+  50% { transform: translate3d(-6%, 3%, 0) scale(1.12); }
+  100% { transform: translate3d(4%, -2%, 0) scale(1.04); }
+}

--- a/apps/web/src/locales/en/translation.json
+++ b/apps/web/src/locales/en/translation.json
@@ -1765,7 +1765,10 @@
         "read": "Resume read",
         "reading": "Reading resume...",
         "allowed": "Read allowed"
-      }
+      },
+      "tasks": "Tasks",
+      "completed": "Completed",
+      "elapsed": "{{seconds}}s"
     },
     "composer": {
       "skills": "Skills",

--- a/apps/web/src/locales/zh/translation.json
+++ b/apps/web/src/locales/zh/translation.json
@@ -1765,7 +1765,10 @@
         "read": "已读取简历",
         "reading": "正在读取简历…",
         "allowed": "已允许读取"
-      }
+      },
+      "tasks": "任务",
+      "completed": "已完成",
+      "elapsed": "{{seconds}}s"
     },
     "composer": {
       "skills": "技能",


### PR DESCRIPTION
> base 是 #197 的分支（本 PR 在其之上）。合并顺序 #196 → #197 → 本 PR，GitHub 会逐级自动重定向。
> 配套后端：Magic-Core#157。

## 为什么

此前清单是**一条时间线导轨 + 骑在上面的 orb**：读得出进度，但一次运行在对话里**没有边界**——三张清单连着出现时，分不清哪几步属于哪一次。

现在它是一张**有容器的卡**，跑完能收起，「这一轮做了什么」于是成了一个可以整体折叠的东西。

## 每行的形态由 agent 自己声明

`agentActivity.ts` 里原本有一条明确的自我约束：九种 orb 形态**刻意只用六种**，因为另外三种「没有能对应它们的真实事件，硬套就又成了演一个并没有发生的状态」。

这条约束现在被**正当地**放宽了——不是我们开始猜，而是**有了真实来源**：`todo.activity` 由 agent 在 `write_todos` 里自己标（后端从 `[[kind:label]]` 派生）。它没说才退回本轮整体活动，再没有才是 `working`。

## 高度改成物理弹簧

不是审美偏好。先做了 HTML 原型、把参照产品的高度逐帧量了出来：

```
长高:  165 →+6→ 171 →+3→ 174 →+2→ 176 →+2→ 178 →+2→ 180 →+2→ 182
```

增量单调衰减、**从不冲过头**——这是**临界阻尼弹簧**，不是会回弹的弹簧振子。

换掉 CSS transition 的理由**不是曲线好看，是速度可以被继承**：任务行是成串到达的（一次运行里四五次追加很常见），transition 每次都从零速度重启，看起来一顿一顿；弹簧带着上一次的余速接着走。

`useSpringHeight` 里那三条注释全是原型踩出来的坑，不是风格选择：

1. 测量用 `getBoundingClientRect().height` 不用 `offsetHeight`——后者**四舍五入成整数**，13.5px 字号配 9px 间距必然算出小数，抹掉的那不到 1px 正好是最后一行的字母下伸部
2. 内容容器**只能用 padding 不能用 margin**——两种测量都不含 margin，留了就被 `overflow:hidden` 裁掉
3. 每次改动都要重新量（**包括标记完成时**）——目标值陈了就会裁

所以「测量口径」被收进这一个 hook，不许各处随手 `offsetHeight`。另外挂了 `ResizeObserver` 盯内容盒：字体加载完、侧栏开合都会重排，而侧栏开合**不触发 window resize**。

## 计量只显示耗时，不显示 token

`llm_usage` 一直在流，渲染它是一行的事。但原始 token 数对求职者没有意义，只会把「用一次要花多少」变成每轮都在盯的数字——这与积分对外只回百分比的既定口径也是一致的。跑完即定格，否则一张已结束的卡看起来还在工作。

## 验证

- `tsc --noEmit` 干净；`next lint` 零 warning/error；`next build` 通过；`i18n:check` 通过（新增 `aiLab.chat.tasks/completed/elapsed`，zh + en）
- `app.test.ts` 新增 `testTasksCard`，并用故意改坏的方式验证过它确实在执行：
  - 两条判据从 ChatThread 搬到 TasksCard 后行为不变（空清单不算跑完、一条未完成就不算、子代理清单不退场）
  - **片段降级**：`segmentsOf` 抽成导出的纯函数——那是唯一一处会因为后端没发 `segments` 而**静默退化**的地方，内联在 JSX 里没有断言钉得住它

视觉终验交你：起 dev server 跑一次「优化简历」，看清单从 0/N 长到 N/N 再收起；连着追加几行时留意高度是不是连贯的。

🤖 Generated with [Claude Code](https://claude.com/claude-code)