### PR TITLE
feat: refine resume section field layout

### DIFF
--- a/apps/web/scripts/verify-custom-sections.tsx
+++ b/apps/web/scripts/verify-custom-sections.tsx
@@ -1,13 +1,11 @@
 /**
  * Does a custom section actually reach the page?
  *
- * The bug this guards against is not a crash — it is silence. A section key no
- * template declares used to render nowhere at all, and item `customFields`
- * were dropped by any fieldMap that did not name them. Both survived every
- * layer above the renderer, so nothing failed; the content simply was not
- * there. That is only catchable by rendering and looking.
+ * This guards both sides of the custom-section contract: an undeclared section
+ * must still reach every template/export, and optional item fields must remain
+ * visible when present without affecting built-in sections.
  *
- * Run: node scripts/verify-custom-sections.mjs
+ * Run: pnpm verify:sections
  */
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
@@ -21,9 +19,11 @@ import { MagicResumeRenderer } from '../../../packages/resume-templates/src/rend
 import { MagicResumePdfDocument } from '../../../packages/resume-templates/src/pdf/MagicResumePdfDocument';
 
 const CUSTOM_HEADING = '个人优势';
-const ITEM_NAME = '综合能力';
+const LEGACY_ITEM_NAME = '综合能力';
 const CUSTOM_FIELD_NAME = '获奖等级';
 const CUSTOM_FIELD_VALUE = '国赛三等奖';
+const CUSTOM_DATE = '2024.06';
+const DESCRIPTION_TEXT = '熟练使用 Claude Code、Cursor、Codex';
 const SKILL_NAME = 'TypeScript';
 const LANGUAGE_NAME = '英语';
 
@@ -63,9 +63,9 @@ const resume = {
       {
         id: 'ps1',
         visible: true,
-        name: ITEM_NAME,
-        summary:
-          '<ul><li>熟练使用 Claude Code、Cursor、Codex</li><li>英语 CET-4、CET-6</li></ul>',
+        name: LEGACY_ITEM_NAME,
+        date: CUSTOM_DATE,
+        summary: '<ul><li>熟练使用 Claude Code、Cursor、Codex</li><li>英语 CET-4、CET-6</li></ul>',
         customFields: [
           { id: 'cf1', name: CUSTOM_FIELD_NAME, value: CUSTOM_FIELD_VALUE },
         ],
@@ -111,9 +111,9 @@ async function main() {
 
     const problems = [];
     if (!text.includes(CUSTOM_HEADING)) problems.push('缺标题');
-    if (!text.includes(ITEM_NAME)) problems.push('缺条目');
-    if (!text.includes(CUSTOM_FIELD_NAME)) problems.push('缺自定义字段名');
-    if (!text.includes(CUSTOM_FIELD_VALUE)) problems.push('缺自定义字段值');
+    if (!text.includes(LEGACY_ITEM_NAME)) problems.push('缺自定义条目标题');
+    if (!text.includes(CUSTOM_DATE)) problems.push('缺自定义条目时间');
+    if (!text.includes(CUSTOM_FIELD_NAME) || !text.includes(CUSTOM_FIELD_VALUE)) problems.push('缺自定义字段');
     // The section it always had must not have been disturbed.
     if (!text.includes('某公司')) problems.push('内置段落丢失');
     // A sidebar-rendered built-in used to be synthesised a second time into the
@@ -175,7 +175,9 @@ async function main() {
   pdfText = pdfText.replace(/\s/g, '');
 
   check('heading is in the export', pdfText.includes(CUSTOM_HEADING));
-  check('item is in the export', pdfText.includes(ITEM_NAME));
+  check('description is in the export', pdfText.includes(DESCRIPTION_TEXT.replace(/\s/g, '')));
+  check('item title is in the export', pdfText.includes(LEGACY_ITEM_NAME));
+  check('item date is in the export', pdfText.includes(CUSTOM_DATE));
   check(
     'custom fields are in the export',
     pdfText.includes(CUSTOM_FIELD_NAME) && pdfText.includes(CUSTOM_FIELD_VALUE),

--- a/apps/web/src/lib/constants/dynamicFormFields.ts
+++ b/apps/web/src/lib/constants/dynamicFormFields.ts
@@ -29,7 +29,7 @@ const experienceFields: FieldConfig[] = [
 // ];
 
 const skillsFields: FieldConfig[] = [
-    { key: 'name', labelKey: 'dynamicForm.fields.skills.name.label', type: 'input', placeholderKey: 'dynamicForm.fields.skills.name.placeholder', required: true },
+    { key: 'name', labelKey: 'dynamicForm.fields.skills.name.label', type: 'input', placeholderKey: 'dynamicForm.fields.skills.name.placeholder' },
     { key: 'level', labelKey: 'dynamicForm.fields.skills.level.label', type: 'input', placeholderKey: 'dynamicForm.fields.skills.level.placeholder' },
 ];
 
@@ -41,12 +41,12 @@ const projectsFields: FieldConfig[] = [
 ];
 
 const languagesFields: FieldConfig[] = [
-    { key: 'language', labelKey: 'dynamicForm.fields.languages.language.label', type: 'input', placeholderKey: 'dynamicForm.fields.languages.language.placeholder', required: true },
+    { key: 'language', labelKey: 'dynamicForm.fields.languages.language.label', type: 'input', placeholderKey: 'dynamicForm.fields.languages.language.placeholder' },
     { key: 'level', labelKey: 'dynamicForm.fields.languages.level.label', type: 'input', placeholderKey: 'dynamicForm.fields.languages.level.placeholder' },
 ];
 
 const certificatesFields: FieldConfig[] = [
-    { key: 'name', labelKey: 'dynamicForm.fields.certificates.name.label', type: 'input', placeholderKey: 'dynamicForm.fields.certificates.name.placeholder', required: true },
+    { key: 'name', labelKey: 'dynamicForm.fields.certificates.name.label', type: 'input', placeholderKey: 'dynamicForm.fields.certificates.name.placeholder' },
     { key: 'issuer', labelKey: 'dynamicForm.fields.certificates.issuer.label', type: 'input', placeholderKey: 'dynamicForm.fields.certificates.issuer.placeholder' },
     { key: 'date', labelKey: 'dynamicForm.fields.certificates.date.label', type: 'input', placeholderKey: 'dynamicForm.fields.certificates.date.placeholder' },
 ];
@@ -55,12 +55,12 @@ const certificatesFields: FieldConfig[] = [
  * Fields for a section the app does not know about — one the resume brought
  * with it, or one the user created.
  *
- * Kept to the two that mean the same thing in any section: a heading and a
- * date. Everything else a custom section wants goes in the rich-text box
- * (bound to `summary` for every section) or in the item's own custom fields.
+ * Custom sections keep the flexible item shape from the original form, but
+ * every field is optional. The section label is the section heading; the item
+ * title is useful context when present, not an identity or validation key.
  */
 const customSectionFields: FieldConfig[] = [
-    { key: 'name', labelKey: 'dynamicForm.fields.custom.name.label', type: 'input', placeholderKey: 'dynamicForm.fields.custom.name.placeholder', required: true },
+    { key: 'name', labelKey: 'dynamicForm.fields.custom.name.label', type: 'input', placeholderKey: 'dynamicForm.fields.custom.name.placeholder' },
     { key: 'date', labelKey: 'dynamicForm.fields.custom.date.label', type: 'input', placeholderKey: 'dynamicForm.fields.custom.date.placeholder' },
 ];
 

--- a/packages/resume-templates/src/pdf/MagicResumePdfDocument.tsx
+++ b/packages/resume-templates/src/pdf/MagicResumePdfDocument.tsx
@@ -803,16 +803,35 @@ const ListSectionBlock = ({ component, items, context }: {
       <View style={{ gap: 6 }}>
         {items.map((item, index) => {
           const record = item as Record<string, unknown>;
+          const sectionKey = component.dataBinding.startsWith('sections.')
+            ? component.dataBinding.slice('sections.'.length)
+            : '';
+          const inlineItemFields = sectionKey === 'skills' || sectionKey === 'languages';
+          const itemName = getFieldValue(record, fields.itemName);
+          const itemDetail = getFieldValue(record, fields.itemDetail);
+          const itemDate = getFieldValue(record, fields.date);
           return (
             <View key={item.id || index} wrap={false}>
-              <Text style={{ color: context.colors.text, fontSize: bodyFontSize, fontWeight: fieldWeight }}>{getFieldValue(record, fields.itemName)}</Text>
-              <Text style={{ color: context.colors.text, fontSize: bodyFontSize }}>{getFieldValue(record, fields.itemDetail)}</Text>
-              <DateText
-                value={getFieldValue(record, fields.date)}
-                color={context.colors.textSecondary}
-                fontFamily={dateFontFamily}
-                fontSize={bodyFontSize}
-              />
+              {inlineItemFields ? (
+                <View style={{ flexDirection: 'row', flexWrap: 'nowrap', alignItems: 'center', gap: 8, padding: 0, margin: 0 }}>
+                  {itemName ? <Text style={{ color: context.colors.text, fontSize: bodyFontSize, fontWeight: fieldWeight }}>{itemName}</Text> : null}
+                  {itemDetail ? <Text style={{ color: context.colors.text, fontSize: bodyFontSize }}>{itemDetail}</Text> : null}
+                </View>
+              ) : (
+                <>
+                  {itemName ? <Text style={{ color: context.colors.text, fontSize: bodyFontSize, fontWeight: fieldWeight }}>{itemName}</Text> : null}
+                  {itemDetail ? <Text style={{ color: context.colors.text, fontSize: bodyFontSize }}>{itemDetail}</Text> : null}
+                  {itemDate ? <DateText value={itemDate} color={context.colors.textSecondary} fontFamily={dateFontFamily} fontSize={bodyFontSize} /> : null}
+                </>
+              )}
+              {inlineItemFields ? (
+                <DateText
+                  value={itemDate}
+                  color={context.colors.textSecondary}
+                  fontFamily={dateFontFamily}
+                  fontSize={bodyFontSize}
+                />
+              ) : null}
               <ItemCustomFields item={item} context={context} fontSize={bodyFontSize} />
               <Description
                 value={getFieldValue(record, fields.summary)}

--- a/packages/resume-templates/src/templateLayout/ListSection.tsx
+++ b/packages/resume-templates/src/templateLayout/ListSection.tsx
@@ -7,6 +7,17 @@ interface Item {
   [key: string]: unknown;
 }
 
+const INLINE_ITEM_ROW_STYLE: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'row',
+  flexWrap: 'nowrap',
+  alignItems: 'center',
+  columnGap: '1rem',
+  padding: 0,
+  margin: 0,
+  whiteSpace: 'nowrap',
+};
+
 interface Props {
   title: string;
   items: Item[];
@@ -56,36 +67,42 @@ export const ListSection = React.memo(function ListSection({ title, items, field
         {items.map((item, idx) => {
           const summary = getFieldEntry(item, fieldMap.summary);
           const itemName = getFieldEntry(item, fieldMap.itemName);
+          const itemDetail = getFieldValue(item, fieldMap.itemDetail);
+          const itemDate = getFieldValue(item, fieldMap.date);
           const itemId = item.id != null ? String(item.id) : null;
+          const inlineItemFields = sectionKey === 'skills' || sectionKey === 'languages';
+          const renderedItemName = itemName && sectionKey && itemId ? (
+            <Editable
+              target={{
+                sectionKey,
+                itemId,
+                fieldKey: itemName.key,
+                kind: 'text',
+                label: `${title} · 第 ${idx + 1} 条`,
+              }}
+              text={itemName.value}
+            />
+          ) : (
+            itemName?.value
+          );
+          const itemContent = inlineItemFields ? (
+            <div style={INLINE_ITEM_ROW_STYLE}>
+              {itemName && <div className="font-bold">{renderedItemName}</div>}
+              {itemDetail && <span>{itemDetail}</span>}
+            </div>
+          ) : (
+            <>
+              {itemName && <div className="font-bold">{renderedItemName}</div>}
+              {itemDetail && <div>{itemDetail}</div>}
+            </>
+          );
           return (
             <li className="space-y-2" key={itemId || idx}>
               <div>
-                {/* The item title is the only translatable/editable text for
-                    skills / languages / certificates — make it an editable anchor
-                    so AI batch changes (e.g. translation) can diff it in place.
-                    Falls back to plain text when the canvas isn't enabled. */}
-                <div className="font-bold">
-                  {itemName && sectionKey && itemId ? (
-                    <Editable
-                      target={{
-                        sectionKey,
-                        itemId,
-                        fieldKey: itemName.key,
-                        kind: 'text',
-                        label: `${title} · 第 ${idx + 1} 条`,
-                      }}
-                      text={itemName.value}
-                    />
-                  ) : (
-                    getFieldValue(item, fieldMap.itemName)
-                  )}
-                </div>
-                {getFieldValue(item, fieldMap.itemDetail) && (
-                  <div>{getFieldValue(item, fieldMap.itemDetail)}</div>
-                )}
-                {getFieldValue(item, fieldMap.date) && (
-                  <div>{getFieldValue(item, fieldMap.date)}</div>
-                )}
+                {/* Item names stay editable in the AI canvas; empty optional
+                    fields simply leave no placeholder line behind. */}
+                {itemContent}
+                {itemDate && <div>{itemDate}</div>}
                 {/* Fields the user added by hand. Rendered explicitly, not
                     through the fieldMap: `getFieldValue` drops any key a
                     fieldMap does not declare, so a field somebody typed would


### PR DESCRIPTION
## Summary

- 让自定义模块的标题、时间字段保持可选，空字段不再产生空白占位。
- 技能、语言名称与等级保持同行显示；证书名称、等级、日期保持分行显示。
- 恢复普通模块自定义字段编辑器行为，移除不必要的侧栏与独立 CustomSection 渲染改动。
- 同步更新 HTML 预览与 PDF 的 ListSection 排版逻辑。
- 优化 ListSection：提取同行样式、减少字段重复读取和重复 JSX。

## Validation

- `pnpm --filter @magic-resume/resume-templates build`
- `pnpm --filter @magic-resume/web lint`
- `pnpm --filter @magic-resume/web test:unit`
- `pnpm --filter @magic-resume/web verify:sections`
- `git diff --check`

仓库 pre-commit 的全量 Astro 检查因缺少 `@astrojs/check` 进入交互安装，未作为本次变更验证依据；以上定向检查均已通过。