### PR TITLE
:sparkles: feat(web): read public app URL at runtime

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { headers } from "next/headers";
 import "./globals.css";
 import { ClerkProvider } from '@clerk/nextjs';
 
@@ -16,25 +17,29 @@ import { HttpClientProvider } from "@/components/providers/HttpClientProvider";
 import { GlobalErrorListener } from "@/components/providers/GlobalErrorListener";
 import { CommercialRuntimeProvider } from "@/lib/commercial/runtime";
 import { RuntimeEnvScript } from "@/lib/commercial/runtime-env";
+import { runtimePublicUrl } from "@/lib/config/runtime-public-url";
 import { CloudAuthBridge } from "@/lib/auth";
 import { NotificationRealtimeProvider } from "@/components/providers/NotificationRealtimeProvider";
 
-export const metadata: Metadata = {
-  // The application is a product surface, not the public marketing site. Keep
-  // its canonical base on the app host and opt the whole surface out of
-  // indexing; landing/docs own the searchable entity pages.
-  metadataBase: new URL(process.env.NEXT_PUBLIC_APP_URL || 'https://app.magic-resume.cn'),
-  ...metaConfig.Landing,
-  robots: {
-    index: false,
-    follow: false,
-    googleBot: {
+export async function generateMetadata(): Promise<Metadata> {
+  await headers();
+  return {
+    // The application is a product surface, not the public marketing site. Keep
+    // its canonical base on the app host and opt the whole surface out of
+    // indexing; landing/docs own the searchable entity pages.
+    metadataBase: new URL(runtimePublicUrl()),
+    ...metaConfig.Landing,
+    robots: {
       index: false,
       follow: false,
-      noimageindex: true,
+      googleBot: {
+        index: false,
+        follow: false,
+        noimageindex: true,
+      },
     },
-  },
-};
+  };
+}
 
 // Provider tree (cloud):    ClerkProvider → CloudAuthBridge → HttpClientProvider → ...
 // Provider tree (self-hosted): Fragment → HttpClientProvider → ... (default context)

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,4 +1,7 @@
 import { MetadataRoute } from 'next'
+import { runtimePublicUrl } from '@/lib/config/runtime-public-url'
+
+export const dynamic = 'force-dynamic'
 
 // robots.txt 的分组语义：一个爬虫只服从**最具体**的那一组，且那一组会**完全替换**
 // `*` 组 —— 不是叠加。所以任何具名 UA 组都必须自带完整的 disallow，
@@ -19,7 +22,7 @@ const DISALLOW = [
 // `robots: { index: false, follow: false }` 明确要求除名，才是能真正生效的那条路。
 
 export default function robots(): MetadataRoute.Robots {
-  const baseUrl = (process.env.NEXT_PUBLIC_APP_URL || 'https://app.magic-resume.cn').replace(/\/+$/, '')
+  const baseUrl = runtimePublicUrl()
 
   return {
     rules: [

--- a/apps/web/src/lib/config/runtime-public-url.ts
+++ b/apps/web/src/lib/config/runtime-public-url.ts
@@ -1,0 +1,12 @@
+/** Server-only site origin; read at request time so a digest can be promoted. */
+export function runtimePublicUrl(): string {
+  const url = new URL(
+    process.env.APP_PUBLIC_URL ||
+      process.env.NEXT_PUBLIC_APP_URL ||
+      'https://app.magic-resume.cn',
+  );
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw new Error('APP_PUBLIC_URL must be an HTTP(S) URL');
+  }
+  return url.origin;
+}


### PR DESCRIPTION
Commercial Web needs one verified image to run in both PRT and production. The public application URL was previously fixed at build time, so metadata and robots output could point at the wrong environment after promotion.

This change reads `APP_PUBLIC_URL` at request time, generates metadata dynamically, and renders `robots.txt` from the same runtime value. The Commercial image workflow can now promote the same digest while changing only runtime configuration.

Validation:

- `pnpm --filter @magic-resume/web test`
- repository pre-commit lint and production build
- Commercial overlay production build
- the same Commercial image emitted distinct PRT and production Host/Sitemap values

Dependency: merge this before enabling the Commercial OpenShip release workflow.
